### PR TITLE
Fix Custom Projectile collision + lifetime callback bugs

### DIFF
--- a/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/CustomProjectile.cs
+++ b/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/CustomProjectile.cs
@@ -1,6 +1,7 @@
 ﻿using EEC.EnemyCustomizations.Shared;
 using EEC.Utils.Json.Elements;
 using Player;
+using SNetwork;
 using System.Text.Json.Serialization;
 using UnityEngine;
 
@@ -40,10 +41,10 @@ namespace EEC.CustomSettings.CustomProjectiles
 
         public void DoCollisionEffect(Vector3 projectilePosition, PlayerAgent player = null)
         {
-            if (Explosion?.Enabled ?? false)
+            if (SNet.IsMaster && (Explosion?.Enabled ?? false))
                 Explosion.DoExplode(projectilePosition);
 
-            if (player == null)
+            if (player == null || !player.IsLocallyOwned)
                 return;
 
             if (Knockback?.Enabled ?? false)

--- a/ExtraEnemyCustomization/Events/Inject/Inject_ProjectileTargeting.cs
+++ b/ExtraEnemyCustomization/Events/Inject/Inject_ProjectileTargeting.cs
@@ -11,7 +11,7 @@ namespace EEC.Events.Inject
         [HarmonyWrapSafe]
         internal static void Prefix(ProjectileTargeting __instance)
         {
-            if (__instance.m_endLifeTime < Clock.Time)
+            if (!__instance.m_active && __instance.m_endLifeTime < Clock.Time)
             {
                 ProjectileEvents.OnLifeTimeDone(__instance);
             }


### PR DESCRIPTION
Fixes 2 primary bugs:

1. Collision effects (explosion, bleed, etc.) firing for every single client rather than only the local client*.
2. Projectiles that collide with walls or players still triggering LifetimeDone events after 5 seconds.

*Since explosions can trigger on walls, they are entirely determined by the host instead.