### PR TITLE
1.8.8 changes

### DIFF
--- a/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/CustomProjectile.cs
+++ b/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/CustomProjectile.cs
@@ -26,6 +26,7 @@ namespace EEC.CustomSettings.CustomProjectiles
         public ValueBase TrailWidth { get; set; } = ValueBase.Unchanged;
         public Color GlowColor { get; set; } = Color.yellow;
         public ValueBase GlowRange { get; set; } = ValueBase.Unchanged;
+        public uint CollisionSoundID { get; set; } = 0u;
         public ValueBase Damage { get; set; } = ValueBase.Unchanged;
         public ValueBase Infection { get; set; } = ValueBase.Unchanged;
         [JsonPropertyName("SpawnProjectileOnCollideWorld")]

--- a/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/Inject/Inject_ProjectileBase_Collision.cs
+++ b/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/Inject/Inject_ProjectileBase_Collision.cs
@@ -1,0 +1,44 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EEC.CustomSettings.CustomProjectiles.Inject
+{
+    [HarmonyPatch(typeof(ProjectileBase), nameof(ProjectileBase.Collision))]
+    internal static class Inject_ProjectileBase_Collision
+    {
+        [HarmonyWrapSafe]
+        internal static void Postfix(ProjectileBase __instance)
+        {
+            var instanceData = CustomProjectileManager.GetInstanceData(__instance.gameObject.GetInstanceID());
+            if (instanceData == null) return;
+
+            uint soundID = instanceData.Settings.CollisionSoundID;
+            if (soundID == 0u)
+            {
+                // Cancel vanilla sound FX (bugged, happens at origin, icky)
+                if (__instance.m_maxInfection > 0)
+                {
+                    var players = CellSound.Current.m_dynamicPlayers;
+                    players[^1].Recycle();
+                    players.RemoveAt(players.Count - 1);
+                }
+                return;
+            }
+
+            // If sound was already made, reuse it
+            if (__instance.m_maxInfection > 0)
+            {
+                var player = CellSound.Current.m_dynamicPlayers[^1];
+                player.Stop();
+                player.Post(soundID, __instance.m_myPos);
+            }
+            // Otherwise make our own
+            else
+            {
+                CellSound.Post(soundID, __instance.m_myPos);
+            }
+        }
+    }
+}

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
@@ -94,6 +94,14 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                     return;
 
                 RevertState:
+                    // If enemy woke up during StandStill, then revert to awake state instead
+                    if (_prevState == ES_StateEnum.Hibernate || _prevState == ES_StateEnum.HibernateWakeUp)
+                    {
+                        // Can't check enum since it doesn't get updated by EB_Hibernate switching to combat
+                        if (Agent.AI.m_behaviour.CurrentState.TryCast<EB_Hibernating>() == null)
+                            _prevState = ES_StateEnum.PathMove;
+                    }
+
                     Agent.Locomotion.ChangeState(_prevState);
                 }
             }
@@ -102,6 +110,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         public abstract bool RunUpdateOnlyWhileExecuting { get; }
         public abstract bool AllowEABAbilityWhileExecuting { get; }
         public abstract bool IsHostOnlyBehaviour { get; }
+        public virtual bool IsHostOnlySetup => IsHostOnlyBehaviour;
 
         private Timer _lazyUpdateTimer = new(LAZYUPDATE_DELAY);
         private bool _executing = false;
@@ -198,7 +207,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
         private void DoSetup()
         {
-            if (IsMasterOnlyAndClient)
+            if (IsHostOnlySetup && !SNet.IsMaster)
                 return;
 
             OnSetup();

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ChainedAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ChainedAbility.cs
@@ -47,6 +47,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         public override bool RunUpdateOnlyWhileExecuting => true;
         public override bool AllowEABAbilityWhileExecuting => true;
         public override bool IsHostOnlyBehaviour => true;
+        public override bool IsHostOnlySetup => false;
 
         private EventBlockBehaviour[] _blockBehaviours = Array.Empty<EventBlockBehaviour>();
         private Timer _endTimer;
@@ -59,7 +60,9 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
             {
                 _ = abSetting.Ability.RegisterBehaviour(Agent);
             }
-            _blockBehaviours = Ability.Abilities.Select(abSetting => new EventBlockBehaviour(abSetting)).ToArray();
+            // Clients need to register the behaviours, but only host needs to cache them
+            if (SNetwork.SNet.IsMaster)
+                _blockBehaviours = Ability.Abilities.Select(abSetting => new EventBlockBehaviour(abSetting)).ToArray();
         }
 
         protected override void OnEnter()

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/DoAnimAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/DoAnimAbility.cs
@@ -24,13 +24,13 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         public override bool IsHostOnlyBehaviour => false;
 
         private Animator _animator;
-        private NavMeshAgent _navAgent;
+        private INavigation _navAgent;
         private Timer _exitTimer;
 
         protected override void OnSetup()
         {
             _animator = Agent.Locomotion.m_animator;
-            _navAgent = Agent.AI.m_navMeshAgent.Cast<NavMeshAgent>();
+            _navAgent = Agent.AI.m_navMeshAgent;
         }
 
         protected override void OnDead()

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/EMPAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/EMPAbility.cs
@@ -3,6 +3,7 @@ using EEC.Utils;
 using EEC.Utils.Unity;
 using Timer = EEC.Utils.Unity.Timer;
 using UnityEngine;
+using UnityEngine.AI;
 
 namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 {
@@ -25,10 +26,16 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
     {
         private EMPState _state = EMPState.None;
         private Timer _stateTimer;
+        private INavigation _navAgent;
 
         public override bool RunUpdateOnlyWhileExecuting => true;
         public override bool AllowEABAbilityWhileExecuting => false;
         public override bool IsHostOnlyBehaviour => false;
+
+        protected override void OnSetup()
+        {
+            _navAgent = Agent.AI.m_navMeshAgent;
+        }
 
         protected override void OnEnter()
         {
@@ -38,9 +45,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
             _stateTimer.Reset(Ability.ChargeUpDuration);
 
             if (Ability.ChargeUpSoundId != 0u)
-            {
                 Agent.Sound.Post(Ability.ChargeUpSoundId);
-            }
 
             if (Ability.InvincibleWhileCharging)
                 Agent.Damage.IsImortal = true;
@@ -83,6 +88,8 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         protected override void OnExit()
         {
             StandStill = false;
+            if (_navAgent.isOnNavMesh)
+                _navAgent.isStopped = false;
 
             if (Ability.InvincibleWhileCharging)
                 Agent.Damage.IsImortal = false;

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/SpawnProjectileAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/SpawnProjectileAbility.cs
@@ -25,10 +25,21 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
     {
         public override bool RunUpdateOnlyWhileExecuting => true;
         public override bool AllowEABAbilityWhileExecuting => true;
-        public override bool IsHostOnlyBehaviour => true;
+        public override bool IsHostOnlyBehaviour => false;
 
         protected override void OnEnter()
         {
+            if (Ability.SoundID != 0u)
+            {
+                Agent.Sound.Post(Ability.SoundID);
+            }
+
+            if (!SNetwork.SNet.IsMaster)
+            {
+                DoExit();
+                return;
+            }
+
             Agents.Agent? target = null;
             if (Agent.AI.IsTargetValid)
             {
@@ -49,11 +60,6 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
             }
 
             Ability.DoSpawn(Agent, target, Agent.ModelRef.m_shooterFireAlign, true);
-
-            if (Ability.SoundID != 0u)
-            {
-                Agent.Sound.Post(Ability.SoundID);
-            }
 
             DoExit();
         }

--- a/ExtraEnemyCustomization/EntryPoint.cs
+++ b/ExtraEnemyCustomization/EntryPoint.cs
@@ -18,7 +18,7 @@ namespace EEC
     //TODO: - Patrolling Hibernation : Too many works to do with this one, this is one of the long term goal
     //TODO: Refactor the CustomBase to support Phase Setting
 
-    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.6")]
+    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.8")]
     [BepInProcess("GTFO.exe")]
     [BepInDependency(MTFOUtil.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("GTFO.InjectLib", BepInDependency.DependencyFlags.HardDependency)]

--- a/wikifiles/EEC Documentation/With Comments/Projectile.jsonc
+++ b/wikifiles/EEC Documentation/With Comments/Projectile.jsonc
@@ -133,6 +133,7 @@
       "TrailWidth": "100%", //BasedValue: Trail effect width (how thick?)
       "GlowColor": "cyan", //Color: Glow Color
       "GlowRange": 1.0, //BasedValue Glow Range
+      "CollisionSoundID": 0, //SoundID to play on collision (3D)
       "Damage": "50% of default", //BasedValue: (Based on PlayerDataBlock.health, Has original Value): Damage to deal 
       "Infection": "0%", //BasedValue: (Based on 1.0, Has Original Value): Add Infection On Hit
       //Editing Infection Will enable the Infection Bomb effect (Includes Particle Effect, Sound Effect), If you don't want it, use Ability/InfectionAttackCustom instead


### PR DESCRIPTION
- Added CollisionSoundID to custom projectile fields
- Fixed projectiles with infection creating splat sounds at world origin
- Fixed ChainedAbility not working on clients.
- Fixed SpawnProjectileAbility sound not working on clients.
- Fixed DoAnimAbility errors.
- Fixed enemies getting stuck in hibernate if they woke up during an EMPAbility animation.