### PR TITLE
1.8.9 changes

### DIFF
--- a/ExtraEnemyCustomization/EntryPoint.cs
+++ b/ExtraEnemyCustomization/EntryPoint.cs
@@ -18,7 +18,7 @@ namespace EEC
     //TODO: - Patrolling Hibernation : Too many works to do with this one, this is one of the long term goal
     //TODO: Refactor the CustomBase to support Phase Setting
 
-    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.6")]
+    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.9")]
     [BepInProcess("GTFO.exe")]
     [BepInDependency(MTFOUtil.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("GTFO.InjectLib", BepInDependency.DependencyFlags.HardDependency)]

--- a/ExtraEnemyCustomization/Inject/Inject_PlayerAgent_ReceiveModification.cs
+++ b/ExtraEnemyCustomization/Inject/Inject_PlayerAgent_ReceiveModification.cs
@@ -1,0 +1,37 @@
+﻿using HarmonyLib;
+using Player;
+using UnityEngine;
+
+namespace ExtraEnemyCustomization.Inject
+{
+    [HarmonyPatch(typeof(PlayerAgent), nameof(PlayerAgent.ReceiveModification))]
+    internal static class Inject_PlayerAgent_ReceiveModification
+    {
+        // Custom value for the amount the screen is flashed by damage.
+        // Vanilla GTFO uses damage / 2f, but non-relativity is cringe.
+        private const float FLASH_CONVERSION = 6f;
+
+        // Health change is not implemented at all in vanilla and prints an error log.
+        [HarmonyWrapSafe]
+        private static void Prefix(PlayerAgent __instance, ref EV_ModificationData data)
+        {
+            // If no health modifications, let it proceed as normal
+            float health = data.health;
+            if (health == 0f) return;
+
+            // Otherwise, set health change to 0 to avoid ugly error log
+            data.health = 0f;
+
+            var damBase = __instance.Damage;
+            if (health > 0f)
+                damBase.AddHealth(health, null);
+            else
+            {
+                health = -health;
+                if (__instance.IsLocallyOwned)
+                    __instance.FPSCamera.AddHitReact(health / damBase.HealthMax * FLASH_CONVERSION, Vector3.up, 0f);
+                damBase.OnIncomingDamage(health, health);
+            }
+        }
+    }
+}


### PR DESCRIPTION
At Becky's behest.

- Adds support for health-modifying fog.

Fields for it exist in the underlying vanilla systems, but it isn't implemented at all and prints an error log - hence this implements all necessary logic.