### PR TITLE
v1.8.10 changes

### DIFF
--- a/ExtraEnemyCustomization/Managers/ConfigManager__EnemyEvents.cs
+++ b/ExtraEnemyCustomization/Managers/ConfigManager__EnemyEvents.cs
@@ -142,7 +142,7 @@ namespace EEC.Managers
             _enemyGlowHolder.RegisterCache(enemyID, forceRebuild: false);
         }
 
-        internal static void FirePrefabBuildEventAll(bool rebuildPrefabs)
+        internal static void FirePrefabBuildEventAll(bool rebuildPrefabs, bool firePrefabEvents = true)
         {
             EnemyDataBlock[] allBlocks = GameDataBlockBase<EnemyDataBlock>.GetAllBlocks();
             foreach (var block in allBlocks)
@@ -171,9 +171,12 @@ namespace EEC.Managers
 
                 RegisterTargetEnemyLookup(block);
                 CacheEnemyEventBuffer(block.persistentID);
-                FirePrefabBuiltEvent(enemyAgentComp, block);
 
-                EnemyPrefabBuilt?.Invoke(enemyAgentComp, block);
+                if (firePrefabEvents)
+                {
+                    FirePrefabBuiltEvent(enemyAgentComp, block);
+                    EnemyPrefabBuilt?.Invoke(enemyAgentComp, block);
+                }
             }
 
             TargetEnemyLookupFullyBuilt();

--- a/ExtraEnemyCustomization/Managers/ConfigManager__Listeners.cs
+++ b/ExtraEnemyCustomization/Managers/ConfigManager__Listeners.cs
@@ -1,5 +1,8 @@
-﻿using GTFO.API.Utilities;
-using System.IO;
+﻿using EEC.Configs;
+using EEC.Configs.Customizations;
+using EEC.EnemyCustomizations;
+using EEC.Utils.Json;
+using GTFO.API.Utilities;
 
 namespace EEC.Managers
 {
@@ -22,23 +25,55 @@ namespace EEC.Managers
 
                         Logger.Log($"Config File Changed: {filename}");
 
-                        ReloadConfig();
-
-                        //TODO: Implement Reload Individual File
-
-                        /*
                         _configInstances[filename].Unloaded();
-                        if (_configInstances[filename] is CustomizationConfig custom)
+
+                        if (_configInstances[filename] is CustomizationConfig oldCustom)
                         {
-                            var settings = custom.GetAllSettings();
-                            foreach (var setting in settings)
+                            var oldSettings = oldCustom.GetAllSettings();
+                            foreach (var setting in oldSettings)
                             {
                                 setting.OnConfigUnloaded();
                             }
                         }
-                        LoadConfig(type);
-                        Current.GenerateBuffer();
-                        */
+
+                        // Not using LoadConfig since it re-reads the file.
+                        // We are using a file handle already, so that errors.
+                        try
+                        {
+                            Config config = (Config) JSON.Deserialize(type, content);
+                            _configInstances[filename] = config;
+                            config.Loaded();
+
+                            var cacheProperty = _cacheProperties
+                            .Where(x => x.PropertyType == type)
+                            .FirstOrDefault();
+                            cacheProperty?.SetValue(null, _configInstances[filename]);
+                        }
+                        catch (Exception exc)
+                        {
+                            Logger.Error($"Exception occurred while reading {e.FullPath} file: {exc}");
+                        }
+
+                        if (_configInstances[filename] is CustomizationConfig custom)
+                        {
+                            try
+                            {
+                                var newSettings = ((CustomizationConfig)_configInstances[filename]).GetAllSettings();
+                                bool hasPrefabEvent = false;
+                                foreach (var setting in newSettings)
+                                {
+                                    setting.OnAssetLoaded();
+                                    if (!hasPrefabEvent && setting is IEnemyPrefabBuiltEvent)
+                                        hasPrefabEvent = true;
+                                }
+                                GenerateBuffer();
+                                FirePrefabBuildEventAll(rebuildPrefabs: hasPrefabEvent, firePrefabEvents: hasPrefabEvent);
+                            }
+                            catch (Exception exc)
+                            {
+                                Logger.Error($"Exception occurred while re-applying configs: {exc}");
+                            }
+                        }
                     }
                 });
             }


### PR DESCRIPTION
Adds LiveEdit support.

Dev notes:
- Previous crash happened because it tried to read the file while the live edit handle was still open.
- Previous code was very barebones and reloaded everything, this only reloads the relevant file and re-caches everything afterwards. If the edited file does not contain settings that modify prefabs, it does not rebuild prefabs.