### PR TITLE
v1.8.12

### DIFF
--- a/ExtraEnemyCustomization/CustomAbilities/EMP/EMPHandlerBase.cs
+++ b/ExtraEnemyCustomization/CustomAbilities/EMP/EMPHandlerBase.cs
@@ -97,6 +97,7 @@ namespace EEC.CustomAbilities.EMP
             if (_destroyed) return;
             if (isEMPD && _state == EMPState.On)
             {
+                OnEMPStart();
                 float delay = GetRandomDelay(MinDelay, MaxDelay);
                 _state = EMPState.FlickerOff;
                 _delayTimer = Clock.Time + delay;
@@ -171,6 +172,11 @@ namespace EEC.CustomAbilities.EMP
         /// This method should shut the device off
         /// </summary>
         protected abstract void DeviceOff();
+
+        /// <summary>
+        /// This method runs when the device is on and gets EMP'd (non-EMP -> EMP)
+        /// </summary>
+        protected virtual void OnEMPStart() { }
 
         /// <summary>
         /// Returns a random delay between the min and max values

--- a/ExtraEnemyCustomization/CustomAbilities/EMP/Handlers/EMPLightHandler.cs
+++ b/ExtraEnemyCustomization/CustomAbilities/EMP/Handlers/EMPLightHandler.cs
@@ -27,8 +27,6 @@ namespace EEC.CustomAbilities.EMP.Handlers
                 Logger.Warning("No Light!");
                 return;
             }
-            _originalIntensity = _light.GetIntensity();
-            _originalColor = _light.m_color;
             _state = EMPState.On;
         }
 
@@ -55,6 +53,15 @@ namespace EEC.CustomAbilities.EMP.Handlers
             {
                 _light.ChangeIntensity(0);
                 _light.ChangeColor(Color.black);
+            }
+        }
+
+        protected override void OnEMPStart()
+        {
+            if (_light != null)
+            {
+                _originalIntensity = _light.GetIntensity();
+                _originalColor = _light.m_color;
             }
         }
     }

--- a/ExtraEnemyCustomization/CustomAbilities/Explosion/ExplosionSync.cs
+++ b/ExtraEnemyCustomization/CustomAbilities/Explosion/ExplosionSync.cs
@@ -9,7 +9,7 @@ namespace EEC.CustomAbilities.Explosion
         protected override void Receive(ExplosionData packet)
         {
             Logger.Verbose($"Explosion Received: [{packet.position}] {packet.damage} {packet.enemyMulti} {packet.minRange} {packet.maxRange}");
-            ExplosionManager.Internal_TriggerExplosion(packet.position, packet.lightColor, packet.damage, packet.enemyMulti, packet.minRange, packet.maxRange);
+            ExplosionManager.Internal_TriggerExplosion(packet.position, packet.lightColor, packet.damage, packet.enemyMulti, packet.minRange, packet.maxRange, packet.enemyMinRange, packet.enemyMaxRange);
         }
     }
 }

--- a/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/CustomProjectile.cs
+++ b/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/CustomProjectile.cs
@@ -39,6 +39,7 @@ namespace EEC.CustomSettings.CustomProjectiles
         public KnockbackSetting Knockback { get; set; } = new();
         public BleedSetting Bleed { get; set; } = new();
         public DrainStaminaSetting DrainStamina { get; set; } = new();
+        public bool HitEnemies { get; set; } = false;
 
         public void DoCollisionEffect(Vector3 projectilePosition, PlayerAgent player = null)
         {

--- a/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/CustomProjectileManager.cs
+++ b/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/CustomProjectileManager.cs
@@ -234,6 +234,31 @@ namespace EEC.CustomSettings.CustomProjectiles
                         };
                     }
 
+                    if (Settings?.HitEnemies ?? false)
+                    {
+                        Vector3 moveVector = default;
+                        Ray moveRay = default;
+                        update += (_) =>
+                        {
+                            moveVector = projectile.m_myPos - projectile.m_lastPos;
+                            float maxDistance = Mathf.Max(0.5f, ProjectileBase.s_tempMove.magnitude);
+                            moveRay.origin = projectile.m_lastPos;
+                            moveVector.Normalize();
+                            moveRay.direction = moveVector;
+                            if (Physics.Raycast(moveRay, out var rayHit, maxDistance, LayerManager.MASK_ENEMY_DAMAGABLE))
+                            {
+                                // Cancel hit if projectile hit the owner
+                                if (projectile.TryGetOwner(out var owner))
+                                {
+                                    var agent = rayHit.collider.GetComponent<IDamageable>().GetBaseAgent();
+                                    if (agent.Pointer == owner.Pointer)
+                                        return;
+                                }
+                                projectile.Collision(moveRay, rayHit);
+                            }
+                        };
+                    }
+
                     MonoBehaviourEventHandler.AttatchToObject(gameObject, onUpdate: update, onDestroyed: (_) =>
                     {
                         RemoveInstanceLookup(instanceID);

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ExplosionAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ExplosionAbility.cs
@@ -17,6 +17,8 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         public float EnemyDamageMulti { get; set; } = 1.0f;
         public float MinRange { get; set; } = 2.0f;
         public float MaxRange { get; set; } = 5.0f;
+        public ValueBase EnemyMinRange { get; set; } = ValueBase.Unchanged;
+        public ValueBase EnemyMaxRange { get; set; } = ValueBase.Unchanged;
         public float NoiseMinRange { get; set; } = 5.0f;
         public float NoiseMaxRange { get; set; } = 10.0f;
         public NM_NoiseType NoiseType { get; set; } = NM_NoiseType.Detectable;

--- a/ExtraEnemyCustomization/EnemyCustomizations/Shared/ExplosionSetting.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Shared/ExplosionSetting.cs
@@ -16,6 +16,8 @@ namespace EEC.EnemyCustomizations.Shared
         public float EnemyDamageMulti { get; set; }
         public float MinRange { get; set; }
         public float MaxRange { get; set; }
+        public ValueBase EnemyMinRange { get; set; }
+        public ValueBase EnemyMaxRange { get; set; }
         public float NoiseMinRange { get; set; }
         public float NoiseMaxRange { get; set; }
         public NM_NoiseType NoiseType { get; set; }
@@ -30,6 +32,8 @@ namespace EEC.EnemyCustomizations.Shared
         public float EnemyDamageMulti { get; set; } = 1.0f;
         public float MinRange { get; set; } = 2.0f;
         public float MaxRange { get; set; } = 5.0f;
+        public ValueBase EnemyMinRange { get; set; } = ValueBase.Unchanged;
+        public ValueBase EnemyMaxRange { get; set; } = ValueBase.Unchanged;
         public float NoiseMinRange { get; set; } = 5.0f;
         public float NoiseMaxRange { get; set; } = 10.0f;
         public NM_NoiseType NoiseType { get; set; } = NM_NoiseType.Detectable;

--- a/ExtraEnemyCustomization/EnemyCustomizations/Shared/Extensions/ExplosionExtension.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Shared/Extensions/ExplosionExtension.cs
@@ -60,6 +60,8 @@ namespace EEC.EnemyCustomizations.Shared
                     enemyMulti = setting.EnemyDamageMulti,
                     minRange = setting.MinRange,
                     maxRange = setting.MaxRange,
+                    enemyMinRange = setting.EnemyMinRange.GetAbsValue(setting.MinRange),
+                    enemyMaxRange = setting.EnemyMaxRange.GetAbsValue(setting.MaxRange),
                     lightColor = setting.LightColor
                 });
             }

--- a/ExtraEnemyCustomization/EnemyCustomizations/Strikers/StrikerTentacleCustom.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Strikers/StrikerTentacleCustom.cs
@@ -8,21 +8,28 @@ namespace EEC.EnemyCustomizations.Strikers
 {
     using EaseFunc = Func<float, float, float, float, float>;
 
-    public sealed class StrikerTentacleCustom : EnemyCustomBase, IEnemyPrefabBuiltEvent
+    public sealed class StrikerTentacleCustom : EnemyCustomBase, IEnemySpawnedEvent
     {
         public GPUCurvyType[] TentacleTypes { get; set; } = Array.Empty<GPUCurvyType>();
         public TentacleSettingData[] TentacleSettings { get; set; } = Array.Empty<TentacleSettingData>();
+        public ValueBase MaxRange { get; set; } = ValueBase.Unchanged;
 
         public override string GetProcessName()
         {
             return "Tentacle";
         }
 
-        public void OnPrefabBuilt(EnemyAgent agent, EnemyDataBlock enemyData)
+        public void OnSpawned(EnemyAgent agent)
         {
             var tentacleComps = agent.GetComponentsInChildren<MovingEnemyTentacleBase>(true);
             var isTypeEnabled = TentacleTypes.Length > 0;
             var isSettingEnabled = TentacleSettings.Length > 0;
+
+            var eabSetting = agent.GetComponentInChildren<EAB_MovingEnemeyTentacle>(true);
+            if (eabSetting != null)
+            {
+                eabSetting.m_absoluteMaxDistanceToHitTarget = MaxRange.GetAbsValue(eabSetting.m_absoluteMaxDistanceToHitTarget);
+            }
 
             for (int i = 0; i < tentacleComps.Length; i++)
             {

--- a/ExtraEnemyCustomization/EntryPoint.cs
+++ b/ExtraEnemyCustomization/EntryPoint.cs
@@ -18,7 +18,7 @@ namespace EEC
     //TODO: - Patrolling Hibernation : Too many works to do with this one, this is one of the long term goal
     //TODO: Refactor the CustomBase to support Phase Setting
 
-    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.11")]
+    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.12")]
     [BepInProcess("GTFO.exe")]
     [BepInDependency(MTFOUtil.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("GTFO.InjectLib", BepInDependency.DependencyFlags.HardDependency)]

--- a/ExtraEnemyCustomization/EntryPoint.cs
+++ b/ExtraEnemyCustomization/EntryPoint.cs
@@ -18,7 +18,7 @@ namespace EEC
     //TODO: - Patrolling Hibernation : Too many works to do with this one, this is one of the long term goal
     //TODO: Refactor the CustomBase to support Phase Setting
 
-    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.9")]
+    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.11")]
     [BepInProcess("GTFO.exe")]
     [BepInDependency(MTFOUtil.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("GTFO.InjectLib", BepInDependency.DependencyFlags.HardDependency)]

--- a/ExtraEnemyCustomization/Events/Inject/Inject_ProjectileBase.cs
+++ b/ExtraEnemyCustomization/Events/Inject/Inject_ProjectileBase.cs
@@ -23,7 +23,10 @@ namespace EEC.Events.Inject
                 return;
 
             if (!baseAgent.TryCastToPlayerAgent(out var playerAgent))
+            {
+                ProjectileEvents.OnCollisionWorld(__instance, hit.collider.gameObject);
                 return;
+            }
 
             ProjectileEvents.OnCollisionPlayer(__instance, playerAgent);
             if (__instance.TryGetOwner(out var owner))

--- a/ExtraEnemyCustomization/Inject/Inject_PlayerAgent_ReceiveModification.cs
+++ b/ExtraEnemyCustomization/Inject/Inject_PlayerAgent_ReceiveModification.cs
@@ -13,6 +13,7 @@ namespace ExtraEnemyCustomization.Inject
 
         // Health change is not implemented at all in vanilla and prints an error log.
         [HarmonyWrapSafe]
+        [HarmonyPriority(Priority.Low)]
         private static void Prefix(PlayerAgent __instance, ref EV_ModificationData data)
         {
             // If no health modifications, let it proceed as normal

--- a/ExtraEnemyCustomization/Utils/ExplosionUtil.cs
+++ b/ExtraEnemyCustomization/Utils/ExplosionUtil.cs
@@ -7,7 +7,7 @@ namespace EEC.Utils
     [Obsolete("Will be moved to ExplosionManager")]
     public static class ExplosionUtil
     {
-        public static void MakeExplosion(Vector3 position, float damage, float enemyMulti, float minRange, float maxRange)
+        public static void MakeExplosion(Vector3 position, float damage, float enemyMulti, float minRange, float maxRange, float enemyMinRange, float enemyMaxRange)
         {
             ExplosionManager.DoExplosion(new ExplosionData()
             {
@@ -16,6 +16,8 @@ namespace EEC.Utils
                 enemyMulti = enemyMulti,
                 minRange = minRange,
                 maxRange = maxRange,
+                enemyMinRange = enemyMinRange,
+                enemyMaxRange = enemyMaxRange,
                 lightColor = ExplosionManager.FlashColor
             });
         }

--- a/wikifiles/EEC Documentation/With Comments/Ability.jsonc
+++ b/wikifiles/EEC Documentation/With Comments/Ability.jsonc
@@ -203,6 +203,8 @@
         "EnemyDamageMulti": 1.0, //Multiplier when enemy is receiving explosion damage
         "MinRange": 5.0, //How far it does maximum damage?
         "MaxRange": 10.0, //How far it does damage?
+        "EnemyMinRange": "Unchanged", //BasedValue: How far it does maximum damage to enemies?
+        "EnemyMaxRange": "Unchanged", //BasedValue: How far it does damage to enemies?
         "NoiseMinRange": 10.0, //How far it awake nearby enemies when it explodes
         "NoiseMaxRange": 15.0, //How for it can be hear by nearby enemy when it explodes
         "NoiseType": "Detectable" //InstaDetect, Detectable, PulseOnly
@@ -214,6 +216,8 @@
         "EnemyDamageMulti": 1.0,
         "MinRange": 5.0,
         "MaxRange": 10.0,
+        "EnemyMinRange": "Unchanged",
+        "EnemyMaxRange": "Unchanged",
         "NoiseMinRange": 10.0,
         "NoiseMaxRange": 15.0,
         "NoiseType": "Detectable"
@@ -228,6 +232,8 @@
         "EnemyDamageMulti": 1.0,
         "MinRange": 5.0,
         "MaxRange": 10.0,
+        "EnemyMinRange": "Unchanged",
+        "EnemyMaxRange": "Unchanged",
         "NoiseMinRange": 10.0,
         "NoiseMaxRange": 15.0,
         "NoiseType": "Detectable"

--- a/wikifiles/EEC Documentation/With Comments/EnemyAbility.jsonc
+++ b/wikifiles/EEC Documentation/With Comments/EnemyAbility.jsonc
@@ -222,6 +222,8 @@
         "EnemyDamageMulti": 1.0,
         "MinRange": 2,
         "MaxRange": 5,
+        "EnemyMinRange": "Unchanged",
+        "EnemyMaxRange": "Unchanged",
         "NoiseMinRange": 5,
         "NoiseMaxRange": 10,
         "NoiseType": "Detectable",

--- a/wikifiles/EEC Documentation/With Comments/Projectile.jsonc
+++ b/wikifiles/EEC Documentation/With Comments/Projectile.jsonc
@@ -184,6 +184,8 @@
         "EnemyDamageMulti": 1.0, //Multiplier when enemy is receiving explosion damage
         "MinRange": 2.0, //How far it does maximum damage?
         "MaxRange": 5.0, //How far it does damage?
+        "EnemyMinRange": "Unchanged", //BasedValue: How far it does maximum damage to enemies?
+        "EnemyMaxRange": "Unchanged", //BasedValue: How far it does damage to enemies?
         "NoiseMinRange": 5.0, //How far it awake nearby enemies when it explodes
         "NoiseMaxRange": 10.0, //How for it can be hear by nearby enemy when it explodes
         "NoiseType": "Detectable" //InstaDetect, Detectable, PulseOnly

--- a/wikifiles/EEC Documentation/With Comments/Projectile.jsonc
+++ b/wikifiles/EEC Documentation/With Comments/Projectile.jsonc
@@ -235,7 +235,8 @@
         "DrainAmountInCombat": 0.1,
         "ResetRecoverTimer": false,
         "ResetRecoverTimerInCombat": false
-      }
+      },
+      "HitEnemies": false //Should it be able to hit enemies?
     }
   ]
 }

--- a/wikifiles/EEC Documentation/With Comments/Tentacle.jsonc
+++ b/wikifiles/EEC Documentation/With Comments/Tentacle.jsonc
@@ -33,18 +33,19 @@
       ],
       "TentacleSettings": [
         {
-          "InEaseType": "EaseOutCirc", //Easing: Type of ease when pulling out the tentalce
+          "InEaseType": "EaseOutCirc", //Easing: Type of ease when pulling out the tentacle
           "OutEaseType": "EaseInExpo", //Easing: Type of ease when pulling in the tentacle
           "InDuration": "50%", //BasedValue: How long it takes to pull out the tentacle?
           "OutDuration": "50%", //BasedValue: How long it takes to pull in the tentacle?
           "HangDuration": "200%", //BasedValue: How long does tentacle stay in air?
-          "SplineWidthSafe": "100%", //BasedValue: Not sure about this lol
-          "SplineWidthPos1": "100%", //BasedValue: How far tentacle be curvy in position 1 (Width)
-          "SplineWidthPos2": "100%", //BasedValue: How far tentacle be curvy in position 2 (Width)
-          "SplineHeightPos1": "100%", //BasedValue: How far tentacle be curvy in position 1 (Height)
-          "SplineHeightPos2": "100%" //BasedValue: How far tentacle be curvy in position 2 (Height)
+          "SplineWidthSafe": "100%", //BasedValue: How far tentacle be curvy if Pos1/2 would go through a wall
+          "SplineWidthPos1": "100%", //BasedValue: How far tentacle be curvy between the head and midpoint (Width)
+          "SplineWidthPos2": "100%", //BasedValue: How far tentacle be curvy between the midpoint and target (Width)
+          "SplineHeightPos1": "100%", //BasedValue: How far tentacle be curvy between the head and midpoint (Height)
+          "SplineHeightPos2": "100%" //BasedValue: How far tentacle be curvy between the midpoint and target (Height)
         }
-      ]
+      ],
+      "MaxRange": 10 //BasedValue: What is the maximum distance the tentacle can hit?
     },
     {
       "Enabled": false,


### PR DESCRIPTION
- Fixes an incompatibility with Oxygen plugin that caused Oxygen health drain to increase health instead.
- Added MaxRange field to custom tentacle fields
- Fixed EMP resetting to default lights
- Added EnemyMinRange and EnemyMaxRange fields to Explosions, which set explosion radius values exclusively for enemies.
- Fixed explosions causing "taken damage" effects when 0 damage was dealt.
- Added HitEnemies field to Projectiles to allow them to hit other enemies.

Dev notes
- Oxygen fix just lets it run its patch first, so technically EEC health drain fog breaks if Oxygen is used, but I doubt both features will be used at the same time.
- EMP resetting merely caches the current light when the EMP turns on. Does not update if there are any light changes during that time; this is meant to be a simple stopgap until a more comprehensive refactor is done.
- CustomTentacle moved setting application from OnPrefab to OnSpawn since StrikerBigTentacle applies its settings on spawn.