### PR TITLE
v1.8.13

### DIFF
--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
@@ -86,6 +86,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                         case ES_StateEnum.DeadFlyer:
                         case ES_StateEnum.DeadSquidBoss:
                         case ES_StateEnum.ScoutScream:
+                        case ES_StateEnum.HibernateWakeUp:
                             break;
 
                         default:
@@ -94,15 +95,18 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                     return;
 
                 RevertState:
-                    // If enemy woke up during StandStill, then revert to awake state instead
-                    if (_prevState == ES_StateEnum.Hibernate || _prevState == ES_StateEnum.HibernateWakeUp)
+                    // If enemy was asleep before StandStill, check if they should revert to sleeping
+                    if (_prevState == ES_StateEnum.Hibernate)
                     {
                         // Can't check enum since it doesn't get updated by EB_Hibernate switching to combat
-                        if (Agent.AI.m_behaviour.CurrentState.TryCast<EB_Hibernating>() == null)
-                            _prevState = ES_StateEnum.PathMove;
+                        if (Agent.AI.m_behaviour.CurrentState.TryCast<EB_Hibernating>() != null)
+                        {
+                            Agent.Locomotion.ChangeState(ES_StateEnum.Hibernate);
+                            return;
+                        }
                     }
 
-                    Agent.Locomotion.ChangeState(_prevState);
+                    Agent.Locomotion.ChangeState(Agent.Locomotion.PathMove);
                 }
             }
         }
@@ -268,6 +272,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
         public void DoEnter()
         {
+            Logger.Log($"Doing enter for ability {BaseAbility.Name}. Need master, is client? {IsMasterOnlyAndClient}, Executing? {Executing}, Destroyed? {AgentDestroyed}");
             if (IsMasterOnlyAndClient)
                 return;
 
@@ -285,6 +290,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
         public void DoExit()
         {
+            Logger.Log($"Doing exit for ability {BaseAbility.Name}. Need master, is client? {IsMasterOnlyAndClient}, Executing? {Executing}, Destroyed? {AgentDestroyed}");
             if (IsMasterOnlyAndClient)
                 return;
 

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
@@ -78,10 +78,6 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                         //When in Specific State it should not change state
                         case ES_StateEnum.Hitreact:
                         case ES_StateEnum.HitReactFlyer:
-                            if (Agent.Locomotion.Hitreact.CurrentReactionType == ES_HitreactType.ToDeath)
-                                break;
-                            goto RevertState;
-
                         case ES_StateEnum.Dead:
                         case ES_StateEnum.DeadFlyer:
                         case ES_StateEnum.DeadSquidBoss:

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
@@ -87,6 +87,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                         case ES_StateEnum.DeadSquidBoss:
                         case ES_StateEnum.ScoutScream:
                         case ES_StateEnum.HibernateWakeUp:
+                        case ES_StateEnum.StuckInGlue:
                             break;
 
                         default:

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
@@ -38,6 +38,28 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
             }
         }
 
+        // Although EEC abilities generally are exclusive with EAB (i.e. enemy does not act during them), some
+        // may be interrupted by certain states - this is used to prevent allowing the enemy to act
+        public bool LocomotionAllowsAbilities
+        {
+            get
+            {
+                return Agent.Locomotion.CurrentStateEnum switch
+                {
+                    ES_StateEnum.StuckInGlue
+                    or ES_StateEnum.Hitreact
+                    or ES_StateEnum.HitReactFlyer
+                    or ES_StateEnum.HibernateWakeUp
+                    or ES_StateEnum.Hibernate
+                    or ES_StateEnum.ScoutScream
+                    or ES_StateEnum.Dead
+                    or ES_StateEnum.DeadFlyer
+                    or ES_StateEnum.DeadSquidBoss => false,
+                    _ => true
+                };
+            }
+        }
+
         public bool Executing
         {
             get => _executing;
@@ -48,7 +70,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                     return;
 
                 _executing = newValue;
-                if (!AllowEABAbilityWhileExecuting && !Agent.Damage.IsStuckInGlue)
+                if (!AllowEABAbilityWhileExecuting && LocomotionAllowsAbilities)
                 {
                     Agent.Abilities.CanTriggerAbilities = !_executing;
                 }

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
@@ -272,7 +272,6 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
         public void DoEnter()
         {
-            Logger.Log($"Doing enter for ability {BaseAbility.Name}. Need master, is client? {IsMasterOnlyAndClient}, Executing? {Executing}, Destroyed? {AgentDestroyed}");
             if (IsMasterOnlyAndClient)
                 return;
 
@@ -290,7 +289,6 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
         public void DoExit()
         {
-            Logger.Log($"Doing exit for ability {BaseAbility.Name}. Need master, is client? {IsMasterOnlyAndClient}, Executing? {Executing}, Destroyed? {AgentDestroyed}");
             if (IsMasterOnlyAndClient)
                 return;
 

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
@@ -48,7 +48,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                     return;
 
                 _executing = newValue;
-                if (!AllowEABAbilityWhileExecuting)
+                if (!AllowEABAbilityWhileExecuting && !Agent.Damage.IsStuckInGlue)
                 {
                     Agent.Abilities.CanTriggerAbilities = !_executing;
                 }
@@ -106,7 +106,6 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                             return;
                         }
                     }
-
                     Agent.Locomotion.ChangeState(Agent.Locomotion.PathMove);
                 }
             }

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ChainedAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ChainedAbility.cs
@@ -130,7 +130,6 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                 {
                     _forceExit = false;
                     DoExit();
-                    _forceExit = true; // In case behaviour force exits after this
                 }
             }
         }

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ChainedAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ChainedAbility.cs
@@ -10,6 +10,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         public EventBlock[] Abilities { get; set; } = Array.Empty<EventBlock>();
 
         public float ExitDelay { get; set; } = 0.0f;
+        public bool ExitWhenAllFinished { get; set; } = true;
         public bool ExitAllInForceExit { get; set; } = true;
         public bool ExitAllInForceExitOnly { get; set; } = false;
         public bool ForceExitOnHitreact { get; set; } = false;
@@ -52,6 +53,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         private EventBlockBehaviour[] _blockBehaviours = Array.Empty<EventBlockBehaviour>();
         private Timer _endTimer;
         private bool _waitingEndTimer = false;
+        private bool _allFinished = false;
         private bool _forceExit = false;
 
         protected override void OnSetup()
@@ -74,7 +76,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
             }
 
             _waitingEndTimer = false;
-            _forceExit = false;
+            _forceExit = true;
         }
 
         protected override void OnUpdate()
@@ -99,6 +101,16 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
             if (isAllDone)
             {
+                if (!_allFinished && Ability.ExitWhenAllFinished)
+                {
+                    foreach (var block in _blockBehaviours)
+                    {
+                        if (block.AbSetting.Ability.TryGetBehaviour(Agent, out var behaviour) && behaviour.Executing)
+                            return;
+                    }
+                    _allFinished = true;
+                }
+
                 if (!_waitingEndTimer)
                 {
                     _endTimer.Reset(Ability.ExitDelay);
@@ -106,6 +118,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                 }
                 else if (_waitingEndTimer && _endTimer.TickAndCheckDone())
                 {
+                    _forceExit = false;
                     DoExit();
                 }
             }
@@ -126,7 +139,6 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         {
             if (Ability.ForceExitOnHitreact)
             {
-                _forceExit = true;
                 DoExit();
             }
         }
@@ -135,7 +147,6 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         {
             if (Ability.ForceExitOnLimbDestroy)
             {
-                _forceExit = true;
                 DoExit();
             }
         }
@@ -144,7 +155,6 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         {
             if (Ability.ForceExitOnDead)
             {
-                _forceExit = true;
                 DoExit();
             }
         }

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ChainedAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ChainedAbility.cs
@@ -130,6 +130,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                 {
                     _forceExit = false;
                     DoExit();
+                    _forceExit = true; // In case behaviour force exits after this
                 }
             }
         }

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/DoAnimAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/DoAnimAbility.cs
@@ -70,7 +70,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
             StandStill = false;
 
             _animator.applyRootMotion = false;
-            if (_navAgent.isOnNavMesh)
+            if (_navAgent.isOnNavMesh && !Agent.Damage.IsStuckInGlue)
             {
                 _navAgent.isStopped = false;
             }

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/EMPAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/EMPAbility.cs
@@ -88,7 +88,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         protected override void OnExit()
         {
             StandStill = false;
-            if (_navAgent.isOnNavMesh)
+            if (_navAgent.isOnNavMesh && !Agent.Damage.IsStuckInGlue)
                 _navAgent.isStopped = false;
 
             if (Ability.InvincibleWhileCharging)

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/SpawnEnemyAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/SpawnEnemyAbility.cs
@@ -121,7 +121,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
         protected override void OnExit()
         {
-            if (_shouldRevertNavMeshAgent)
+            if (_shouldRevertNavMeshAgent && !Agent.Damage.IsStuckInGlue)
             {
                 Agent.AI.m_navMeshAgent.isStopped = false;
             }

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/BehaviourAbilityCustom.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/BehaviourAbilityCustom.cs
@@ -38,7 +38,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities
     public sealed class BehaviourAbilitySetting : AbilitySettingBase
     {
         public float UpdateInterval { get; set; } = 0.15f;
-        public bool ForceExitOnConditionMismatch { get; set; } = false;
+        public ExitConditionTarget ForceExitOnConditionMismatch { get; set; } = ExitConditionTarget.None;
         public AgentModeTarget AllowedMode { get; set; } = AgentModeTarget.Agressive;
         public float AllowedModeTransitionTime { get; set; } = 0.0f;
         public bool KeepOnDead { get; set; } = false;

--- a/ExtraEnemyCustomization/EnemyCustomizations/Models/MaterialCustom.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Models/MaterialCustom.cs
@@ -36,7 +36,11 @@ namespace EEC.EnemyCustomizations.Models
 
         public void OnPrefabBuilt(EnemyAgent agent, EnemyDataBlock enemyData)
         {
-            var charMats = agent.GetComponentInChildren<CharacterMaterialHandler>().m_materialRefs;
+            var charMatHandler = agent.MaterialHandler;
+            var charMats = charMatHandler.m_materialRefs;
+            if (charMats.Count == 0)
+                PopulateMaterialList(agent, charMatHandler);
+
             foreach (var matRef in charMats)
             {
                 var matName = matRef.m_material.name;
@@ -108,6 +112,30 @@ namespace EEC.EnemyCustomizations.Models
                 if (Logger.VerboseLogAllowed)
                     LogVerbose(" - Replaced!");
             }
+        }
+
+        private void PopulateMaterialList(EnemyAgent enemy, CharacterMaterialHandler materialHandler)
+        {
+            var meshRenderers = enemy.GetComponentsInChildren<MeshRenderer>(true);
+            Dictionary<string, MaterialRef> materialToRef = new();
+            foreach (var renderer in meshRenderers)
+            {
+                var material = renderer.material;
+                if (material == null) continue;
+
+                if (!materialToRef.ContainsKey(material.name))
+                {
+                    materialToRef[material.name] = new MaterialRef()
+                    {
+                        m_material = material
+                    };
+                }
+
+                materialToRef[material.name].m_renderers.Add(renderer);
+            }
+            
+            foreach(var matRef in materialToRef.Values)
+                materialHandler.m_materialRefs.Add(matRef);
         }
 
         public sealed class MaterialSwapSet

--- a/ExtraEnemyCustomization/EnemyCustomizations/Models/MaterialCustom.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Models/MaterialCustom.cs
@@ -43,7 +43,7 @@ namespace EEC.EnemyCustomizations.Models
 
             foreach (var matRef in charMats)
             {
-                var matName = matRef.m_material.name;
+                var matName = matRef.m_material.name.Replace(" (Instance)", "", StringComparison.InvariantCulture);
                 if (Logger.VerboseLogAllowed)
                     LogVerbose($" - Debug Info, Material Found: {matName}");
 

--- a/ExtraEnemyCustomization/EntryPoint.cs
+++ b/ExtraEnemyCustomization/EntryPoint.cs
@@ -18,7 +18,7 @@ namespace EEC
     //TODO: - Patrolling Hibernation : Too many works to do with this one, this is one of the long term goal
     //TODO: Refactor the CustomBase to support Phase Setting
 
-    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.12")]
+    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.13")]
     [BepInProcess("GTFO.exe")]
     [BepInDependency(MTFOUtil.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("GTFO.InjectLib", BepInDependency.DependencyFlags.HardDependency)]

--- a/ExtraEnemyCustomization/Utils/EnemyAnimUtil.cs
+++ b/ExtraEnemyCustomization/Utils/EnemyAnimUtil.cs
@@ -98,6 +98,7 @@ namespace EEC.Utils
 
             if (pauseAI)
             {
+                agent.AI.m_navMeshAgent.velocity = UnityEngine.Vector3.zero;
                 if (agent.AI.m_navMeshAgent.isOnNavMesh)
                 {
                     agent.AI.m_navMeshAgent.isStopped = true;

--- a/ExtraEnemyCustomization/Utils/Json/Elements/ExitConditionTarget.cs
+++ b/ExtraEnemyCustomization/Utils/Json/Elements/ExitConditionTarget.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.Json.Serialization;
+
+namespace EEC.Utils.Json.Elements
+{
+    [JsonConverter(typeof(ExitConditionTargetConverter))]
+    public struct ExitConditionTarget
+    {
+        public static readonly ExitConditionTarget All = new(ExitConditionType.Mode | ExitConditionType.Dead | ExitConditionType.Attack | ExitConditionType.State | ExitConditionType.Distance);
+        public static readonly ExitConditionTarget None = new(ExitConditionType.None);
+
+        public ExitConditionType Mode;
+
+        public ExitConditionTarget(ExitConditionType modes)
+        {
+            Mode = modes;
+        }
+
+        public bool HasFlag(ExitConditionType type) => Mode.HasFlag(type);
+    }
+
+    [Flags]
+    public enum ExitConditionType
+    {
+        None = 0,
+        Mode = 1,
+        Dead = 1 << 1,
+        Attack = 1 << 2,
+        State = 1 << 3,
+        Distance = 1 << 4
+    }
+}

--- a/ExtraEnemyCustomization/Utils/Json/Elements/ExitConditionTargetConverter.cs
+++ b/ExtraEnemyCustomization/Utils/Json/Elements/ExitConditionTargetConverter.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EEC.Utils.Json.Elements
+{
+    public sealed class ExitConditionTargetConverter : JsonConverter<ExitConditionTarget>
+    {
+        private static readonly char[] _separators = new char[] { ',', '|' };
+
+        public override ExitConditionTarget Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.False:
+                    return ExitConditionTarget.None;
+
+                case JsonTokenType.True:
+                    return ExitConditionTarget.All;
+
+                case JsonTokenType.String:
+                    var strValue = reader.GetString();
+                    var splitValues = strValue.Split(_separators, StringSplitOptions.RemoveEmptyEntries);
+                    if (splitValues.Length <= 0)
+                    {
+                        throw new JsonException($"There are no entries in {strValue}! Are you sure it's in right format?");
+                    }
+
+                    var target = ExitConditionType.None;
+                    foreach (var str in splitValues)
+                    {
+                        var input = str.ToLowerInvariant().Trim();
+                        switch (input)
+                        {
+                            case "allowedmode":
+                            case "mode":
+                                target |= ExitConditionType.Mode;
+                                continue;
+
+                            case "keepondead":
+                            case "dead":
+                                target |= ExitConditionType.Dead;
+                                continue;
+
+                            case "allowwhileattack":
+                            case "attack":
+                                target |= ExitConditionType.Attack;
+                                continue;
+
+                            case "state":
+                                target |= ExitConditionType.State;
+                                continue;
+
+                            case "distance":
+                                target |= ExitConditionType.Distance;
+                                continue;
+                        }
+                    }
+                    return new ExitConditionTarget(target);
+
+                //Why?????
+                case JsonTokenType.Number:
+                    Logger.Warning("Found flag number value in ExitConditionTarget! : consider changing it to string.");
+                    return new ExitConditionTarget((ExitConditionType)reader.GetInt32());
+
+                default:
+                    throw new JsonException($"Token type: {reader.TokenType} in ExitConditionTarget is not supported!");
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, ExitConditionTarget value, JsonSerializerOptions options)
+        {
+            writer.WriteNumberValue((int)value.Mode);
+        }
+    }
+}

--- a/wikifiles/EEC Documentation/With Comments/EnemyAbility.jsonc
+++ b/wikifiles/EEC Documentation/With Comments/EnemyAbility.jsonc
@@ -12,7 +12,18 @@
       "Abilities": [
         {
           "UpdateInterval": 0.15,
-          "ForceExitOnConditionMismatch": false, //Abort Ability when Condition Mismatch
+          "ForceExitOnConditionMismatch": false, //Abort Ability when certain conditions mismatch.
+          /*
+          Allowed Values:
+            false (none),
+            Mode,
+            Dead,
+            Attack,
+            State,
+            Distance,
+            true (any)
+          Specific conditions can be combined with '|' or ',' like "Mode | Dead | Attack | State".
+          */
           "AllowedMode": "Combat", //AgentTarget: Allowed AgentModes
           "AllowedModeTransitionTime": 0.0, //Wait for this time to use ability after their AgentMode has changed
           "KeepOnDead": false,
@@ -181,6 +192,7 @@
           }
         ],
         "ExitDelay": 0.0,
+        "ExitWhenAllFinished": true, // Exit delay begins only after all abilities finish executing
         "ExitAllInForceExit": true, // Exits abilities when the chain ends
         "ExitAllInForceExitOnly": false, // Exits abilities ONLY when the chain forcibly ends
         "ForceExitOnHitreact": false,


### PR DESCRIPTION
- MaterialCustom now supports flyer bodies (but not tentacles).
- EMP now smoothly gets interrupted by wakeups.
- Fixed EMP or StandStill animations remaining stuck after finishing if the enemy began it during certain states (e.g. attack, scream)
- Fixed EMP or StandStill animations causing the enemy to "slide" with its current velocity.
- Fixed certain abilities that halted the enemy causing it to act after being interrupted by foam.
- A forced exit on BehaviourAbilityCustom is now considered a forced exit for ChainedAbility.
- Added customization for ForceExitOnConditionMismatch to BehaviourAbilityCustom to separate exit conditions from enter conditions.
- Expanded AllowWhileAttack on BehaviourAbilityCustom to additionally check if the enemy started an attack rather than only checking if their attack was out (e.g. tongue is extending to its target).

Dev notes:
- StandStill no longer attempts to revert to the old state at all - it didn't really work with how many states rely on being uninterrupted. Instead, it now reverts to PathMove (or Hibernating if they're asleep), from which the enemy can behave as needed.
- AllowWhileAttack checked a flag that was only true when an attack was actually playing (e.g. tongue is out, shooter is shooting), but not during the start of the attack animation.
- I went for an enum flag style for exit condition customization since it works well for a "slot in what you need" system. Backwards compatibility is unaffected.