### PR TITLE
v1.8.14

### DIFF
--- a/ExtraEnemyCustomization/Configuration.cs
+++ b/ExtraEnemyCustomization/Configuration.cs
@@ -91,7 +91,7 @@ namespace EEC
             ShowExplosionEffect = _showExplosionEffect.Value;
             ShitpostType = _shitpostType.Value;
 
-            _useLiveEdit = BindRdwDevConfig("Live Edit", "Reload Config when they are edited while in-game", false);
+            _useLiveEdit = BindRdwDevConfig("Live Edit", "Reload Config when they are edited while in-game", true);
             _linkMTFOHotReload = BindRdwDevConfig("Reload on MTFO HotReload", "Reload Configs when MTFO's HotReload button has pressed?", true);
             UseLiveEdit = _useLiveEdit.Value;
             LinkMTFOHotReload = _linkMTFOHotReload.Value;

--- a/ExtraEnemyCustomization/CustomAbilities/FogHealth/FogHealthManager.cs
+++ b/ExtraEnemyCustomization/CustomAbilities/FogHealth/FogHealthManager.cs
@@ -1,0 +1,28 @@
+﻿using Player;
+
+namespace EEC.CustomAbilities.FogHealth
+{
+    [CallConstructorOnLoad]
+    public static class FogHealthManager
+    {
+        internal static FogHealthSync Sync { get; private set; } = new();
+
+        static FogHealthManager()
+        {
+            Sync.Setup();
+        }
+
+        public static void DoHealthChange(PlayerAgent agent, float amount)
+        {
+            if (amount > 0) // Sends to host -> host sets & sends health -> clients receive new health
+                agent.Damage.AddHealth(amount, null);
+            else // Sends to all players -> everyone sets the player as having taken damage
+                Sync.SendToPlayer(new FogHealthData() { damage = -amount }, agent);
+        }
+    }
+
+    public struct FogHealthData
+    {
+        public float damage;
+    }
+}

--- a/ExtraEnemyCustomization/CustomAbilities/FogHealth/FogHealthSync.cs
+++ b/ExtraEnemyCustomization/CustomAbilities/FogHealth/FogHealthSync.cs
@@ -1,0 +1,31 @@
+﻿using EEC.Networking;
+using SNetwork;
+
+namespace EEC.CustomAbilities.FogHealth
+{
+    internal sealed class FogHealthSync : SyncedPlayerEvent<FogHealthData>
+    {
+        public override string GUID => "FGH";
+        public override bool SendToTargetOnly => false;
+        public override bool AllowBots => false;
+
+        // Custom value for the amount the screen is flashed by damage.
+        // Vanilla GTFO uses damage / 2f, but non-relativity is cringe.
+        private const float FLASH_CONVERSION = 6f;
+
+        protected override void Receive(FogHealthData packet, SNet_Player receivedPlayer)
+        {
+            if (TryGetPlayerAgent(receivedPlayer, out var agent))
+            {
+                if (Logger.VerboseLogAllowed)
+                    Logger.Verbose($"FogHealth [{agent.PlayerSlotIndex} {packet.damage}]");
+
+                var damage = packet.damage;
+                var damBase = agent.Damage;
+                if (receivedPlayer.IsLocal)
+                    agent.FPSCamera.AddHitReact(damage / damBase.HealthMax * FLASH_CONVERSION, UnityEngine.Vector3.up, 0f);
+                damBase.OnIncomingDamage(damage, damage);
+            }
+        }
+    }
+}

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/DoAnimAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/DoAnimAbility.cs
@@ -73,7 +73,8 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
         protected override void OnExit()
         {
-            StandStill = false;
+            if (Ability.StandStill)
+                StandStill = false;
 
             if (!Ability.StandStill)
             {

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/DoAnimAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/DoAnimAbility.cs
@@ -15,6 +15,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         public float CrossFadeTime { get; set; } = 0.0f;
         public bool AllowUsingEABWhileExecuting { get; set; } = false;
         public bool StandStill { get; set; } = true;
+        public bool ApplyRootMotion { get; set; } = true;
     }
 
     public sealed class DoAnimBehaviour : AbilityBehaviour<DoAnimAbility>
@@ -46,6 +47,11 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
             EnemyAnimUtil.DoAnimationLocal(Agent, Ability.Animation, Ability.CrossFadeTime, true);
 
+            if (!Ability.ApplyRootMotion)
+            {
+                _animator.applyRootMotion = false;
+            }
+
             if (Ability.SoundEvent != 0u)
             {
                 Agent.Sound.Post(Ability.SoundEvent);
@@ -69,10 +75,14 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         {
             StandStill = false;
 
-            _animator.applyRootMotion = false;
-            if (_navAgent.isOnNavMesh && !Agent.Damage.IsStuckInGlue)
+            if (!Ability.StandStill)
             {
-                _navAgent.isStopped = false;
+                _navAgent.isStopped = _navAgent.isOnNavMesh && Agent.IsStopped();
+            }
+
+            if (!Ability.ApplyRootMotion)
+            {
+                _animator.applyRootMotion = Agent.CanApplyRootMotion();
             }
         }
     }

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/EMPAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/EMPAbility.cs
@@ -88,10 +88,8 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         protected override void OnExit()
         {
             StandStill = false;
-            if (_navAgent.isOnNavMesh && !Agent.Damage.IsStuckInGlue)
-                _navAgent.isStopped = false;
 
-            if (Ability.InvincibleWhileCharging)
+            if (Ability.InvincibleWhileCharging && Agent.Locomotion.CurrentStateEnum != Enemies.ES_StateEnum.ScoutScream)
                 Agent.Damage.IsImortal = false;
             Agent.Appearance.InterpolateGlow(Color.black, 0.5f);
 

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/SpawnEnemyAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/SpawnEnemyAbility.cs
@@ -115,7 +115,8 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
         protected override void OnExit()
         {
-            StandStill = false;
+            if (Ability.StopAgent)
+                StandStill = false;
         }
 
         public enum State

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/SpawnEnemyAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/SpawnEnemyAbility.cs
@@ -36,7 +36,6 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
     {
         private int _remainingSpawn = 0;
 
-        private bool _shouldRevertNavMeshAgent = false;
         private State _state;
         private Timer _stateTimer;
 
@@ -47,7 +46,6 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         protected override void OnEnter()
         {
             _remainingSpawn = Ability.TotalCount;
-            _shouldRevertNavMeshAgent = false;
 
             if (_remainingSpawn <= 0)
             {
@@ -55,11 +53,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                 return;
             }
 
-            if (Ability.StopAgent && Agent.AI.m_navMeshAgent.enabled)
-            {
-                Agent.AI.m_navMeshAgent.isStopped = true;
-                _shouldRevertNavMeshAgent = true;
-            }
+            StandStill = Ability.StopAgent;
 
             _state = State.StartDelay;
             _stateTimer.Reset(Ability.Delay);
@@ -121,10 +115,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
         protected override void OnExit()
         {
-            if (_shouldRevertNavMeshAgent && !Agent.Damage.IsStuckInGlue)
-            {
-                Agent.AI.m_navMeshAgent.isStopped = false;
-            }
+            StandStill = false;
         }
 
         public enum State

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/SpawnProjectileAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/SpawnProjectileAbility.cs
@@ -50,6 +50,8 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                 float sqrDistance = float.MaxValue;
                 foreach (var playerAgent in Player.PlayerManager.PlayerAgentsInLevel)
                 {
+                    if (!playerAgent.Alive) continue;
+
                     var tempDistance = (Agent.EyePosition - playerAgent.EyePosition).sqrMagnitude;
                     if (sqrDistance >= tempDistance && !UnityEngine.Physics.Linecast(Agent.EyePosition, playerAgent.EyePosition, LayerManager.MASK_WORLD))
                     {

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/BehaviourAbilityCustom.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/BehaviourAbilityCustom.cs
@@ -43,6 +43,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities
         public float AllowedModeTransitionTime { get; set; } = 0.0f;
         public bool KeepOnDead { get; set; } = false;
         public bool AllowWhileAttack { get; set; } = false;
+        public bool RequireEABAllowed { get; set; } = false;
         public EnemyStateSetting State { get; set; } = new();
         public DistanceSetting DistanceWithLOS { get; set; } = new();
         public DistanceSetting DistanceWithoutLOS { get; set; } = new();

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Handlers/BehaviourUpdateRoutine.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Handlers/BehaviourUpdateRoutine.cs
@@ -54,6 +54,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Handlers
             UpdateUseOrExit(CheckAllowedModeCondition(), ExitConditionType.Mode);
             UpdateUseOrExit(CheckAllowedStateCondition(), ExitConditionType.State);
             UpdateUseOrExit(CheckAttackingCondition(), ExitConditionType.Attack);
+            UpdateUseOrExit(!Setting.RequireEABAllowed || Agent.Abilities.CanTriggerAbilities, ExitConditionType.EABAllowed);
             UpdateUseOrExit(CheckDistanceCondition(), ExitConditionType.Distance);
 
             if (!canUseAbility)

--- a/ExtraEnemyCustomization/EntryPoint.cs
+++ b/ExtraEnemyCustomization/EntryPoint.cs
@@ -18,7 +18,7 @@ namespace EEC
     //TODO: - Patrolling Hibernation : Too many works to do with this one, this is one of the long term goal
     //TODO: Refactor the CustomBase to support Phase Setting
 
-    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.13")]
+    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.14")]
     [BepInProcess("GTFO.exe")]
     [BepInDependency(MTFOUtil.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("GTFO.InjectLib", BepInDependency.DependencyFlags.HardDependency)]

--- a/ExtraEnemyCustomization/Extensions/EnemyAgentExtension.cs
+++ b/ExtraEnemyCustomization/Extensions/EnemyAgentExtension.cs
@@ -75,5 +75,65 @@ namespace EEC
 
             return node;
         }
+
+        public static bool CanUseAbilities(this EnemyAgent agent)
+        {
+            return agent.Locomotion.CurrentStateEnum switch
+            {
+                ES_StateEnum.BirtherGiveBirth
+                or ES_StateEnum.Jump
+                or ES_StateEnum.Hitreact
+                or ES_StateEnum.HitReactFlyer
+                or ES_StateEnum.HibernateWakeUp
+                or ES_StateEnum.Hibernate
+                or ES_StateEnum.ScoutDetection
+                or ES_StateEnum.ScoutScream
+                or ES_StateEnum.Scream
+                or ES_StateEnum.ScreamFlyer
+                or ES_StateEnum.StrikerMelee
+                or ES_StateEnum.StuckInGlue
+                or ES_StateEnum.TriggerFogSphere
+                or ES_StateEnum.Dead
+                or ES_StateEnum.DeadFlyer
+                or ES_StateEnum.DeadSquidBoss => false,
+                _ => true
+            };
+        }
+
+        public static bool IsStopped(this EnemyAgent agent)
+        {
+            return agent.Locomotion.CurrentStateEnum switch
+            {
+                ES_StateEnum.BirtherGiveBirth
+                or ES_StateEnum.ShooterAttack
+                or ES_StateEnum.StrikerAttack
+                or ES_StateEnum.ShooterAttackFlyer
+                or ES_StateEnum.TankAttack
+                or ES_StateEnum.StrikerMelee
+                or ES_StateEnum.ScoutScream
+                or ES_StateEnum.Scream
+                or ES_StateEnum.ScreamFlyer
+                or ES_StateEnum.Hitreact
+                or ES_StateEnum.HitReactFlyer
+                or ES_StateEnum.StuckInGlue
+                or ES_StateEnum.ScoutDetection
+                or ES_StateEnum.Dead
+                or ES_StateEnum.DeadFlyer
+                or ES_StateEnum.DeadSquidBoss => true,
+                _ => false
+            };
+        }
+
+        public static bool CanApplyRootMotion(this EnemyAgent agent)
+        {
+            return agent.Locomotion.CurrentStateEnum switch
+            {
+                ES_StateEnum.ClimbLadder
+                or ES_StateEnum.StuckInGlue
+                or ES_StateEnum.PathMove
+                or ES_StateEnum.PathMoveFlyer => false,
+                _ => true
+            };
+        }
     }
 }

--- a/ExtraEnemyCustomization/Inject/Inject_PlayerAgent_ReceiveModification.cs
+++ b/ExtraEnemyCustomization/Inject/Inject_PlayerAgent_ReceiveModification.cs
@@ -1,16 +1,12 @@
-﻿using HarmonyLib;
+﻿using EEC.CustomAbilities.FogHealth;
+using HarmonyLib;
 using Player;
-using UnityEngine;
 
 namespace ExtraEnemyCustomization.Inject
 {
     [HarmonyPatch(typeof(PlayerAgent), nameof(PlayerAgent.ReceiveModification))]
     internal static class Inject_PlayerAgent_ReceiveModification
     {
-        // Custom value for the amount the screen is flashed by damage.
-        // Vanilla GTFO uses damage / 2f, but non-relativity is cringe.
-        private const float FLASH_CONVERSION = 6f;
-
         // Health change is not implemented at all in vanilla and prints an error log.
         [HarmonyWrapSafe]
         [HarmonyPriority(Priority.Low)]
@@ -23,16 +19,7 @@ namespace ExtraEnemyCustomization.Inject
             // Otherwise, set health change to 0 to avoid ugly error log
             data.health = 0f;
 
-            var damBase = __instance.Damage;
-            if (health > 0f)
-                damBase.AddHealth(health, null);
-            else
-            {
-                health = -health;
-                if (__instance.IsLocallyOwned)
-                    __instance.FPSCamera.AddHitReact(health / damBase.HealthMax * FLASH_CONVERSION, Vector3.up, 0f);
-                damBase.OnIncomingDamage(health, health);
-            }
+            FogHealthManager.DoHealthChange(__instance, health);
         }
     }
 }

--- a/ExtraEnemyCustomization/Networking/SyncedPlayerEvent.cs
+++ b/ExtraEnemyCustomization/Networking/SyncedPlayerEvent.cs
@@ -161,20 +161,21 @@ namespace EEC.Networking
             }
             else
             {
-                if (player.IsLocal)
+                if (SendToTargetOnly)
                 {
-                    Received_Callback(player.Lookup, payload);
-                }
-                else
-                {
-                    if (SendToTargetOnly)
+                    if (player.IsLocal)
                     {
-                        NetworkAPI.InvokeEvent(EventName, payload, player);
+                        Received_Callback(player.Lookup, payload);
                     }
                     else
                     {
-                        NetworkAPI.InvokeEvent(EventName, payload);
+                        NetworkAPI.InvokeEvent(EventName, payload, player);
                     }
+                }
+                else
+                {
+                    NetworkAPI.InvokeEvent(EventName, payload);
+                    Received_Callback(player.Lookup, payload);
                 }
             }
         }

--- a/ExtraEnemyCustomization/Utils/Json/Elements/ExitConditionTarget.cs
+++ b/ExtraEnemyCustomization/Utils/Json/Elements/ExitConditionTarget.cs
@@ -26,6 +26,7 @@ namespace EEC.Utils.Json.Elements
         Dead = 1 << 1,
         Attack = 1 << 2,
         State = 1 << 3,
-        Distance = 1 << 4
+        Distance = 1 << 4,
+        EABAllowed = 1 << 5
     }
 }

--- a/ExtraEnemyCustomization/Utils/Json/Elements/ExitConditionTargetConverter.cs
+++ b/ExtraEnemyCustomization/Utils/Json/Elements/ExitConditionTargetConverter.cs
@@ -54,6 +54,12 @@ namespace EEC.Utils.Json.Elements
                             case "distance":
                                 target |= ExitConditionType.Distance;
                                 continue;
+
+                            case "requireeaballowed":
+                            case "requireeab":
+                            case "eaballowed":
+                                target |= ExitConditionType.EABAllowed;
+                                continue;
                         }
                     }
                     return new ExitConditionTarget(target);

--- a/wikifiles/EEC Documentation/With Comments/EnemyAbility.jsonc
+++ b/wikifiles/EEC Documentation/With Comments/EnemyAbility.jsonc
@@ -21,6 +21,7 @@
             Attack,
             State,
             Distance,
+            EABAllowed,
             true (any)
           Specific conditions can be combined with '|' or ',' like "Mode | Dead | Attack | State".
           */
@@ -28,6 +29,7 @@
           "AllowedModeTransitionTime": 0.0, //Wait for this time to use ability after their AgentMode has changed
           "KeepOnDead": false,
           "AllowWhileAttack": false,
+          "RequireEABAllowed": false, //Can the enemy only use this ability when normal abilities are also allowed?
           "State": {
             "Mode": "DisallowStates", //None, AllowStates, DisallowStates
             "States": [
@@ -298,6 +300,9 @@
         "VoiceEvent": 0,
         "Duration": 1.0,
         "CrossFadeTime": 0.15,
+        "AllowUsingEABWhileExecuting": false, //Can the enemy use abilities/attacks while doing the animation?
+        "StandStill": true, //Locks the enemy state to prevent it from acting 
+        "ApplyRootMotion": true, //Can the animation's movement apply to the enemy?
         "Name": "AnimScream"
       }
     ],


### PR DESCRIPTION
- Added RequireEABAllowed field to BehaviorAbilityCustom to restrict the ability usage if the enemy can't use normal abilities.
- Added StopRootMotion field to DoAnim to restrict animation movement.
- Fixed health-damaging FogCustom only affecting host.
- Fixed EMP and StandStill animations overriding each other and enabling enemy movement early.
- Fixed issues where EMP and StandStill animations could allow enemies to perform actions they shouldn't when interrupted.
- Fixed SpawnProjectiles with "FindTargetIfInvalid" set targeting downed players.
- Enabled LiveEdit by default.

Dev notes:
- StandStill's internal value was changed to an int to track active usages, as the previous boolean type couldn't really support that.
- OnExit is now called before Executing is set to false to allow abilities with StandStill set to revert their state first so `AllowEABAbilityWhileExecuting` can be used correctly.
- Changed SpawnEnemy to use StandStill instead of only stopping their navmesh agent since it seems like StandStill is a more modern approach (was likely added after SpawnEnemy, but I didn't check).
  - On a similar note, I moved the navmesh agent stopping behavior to StandStill to keep everything together.
  - Restoring the stopped agent was mostly removed since switching to PathMove (from exiting StandStill) re-enables it.
- LiveEdit on by default since it's often far more convenient and lighter than HotReload now that it actually works.