### PR TITLE
v1.8.15

### DIFF
--- a/ExtraEnemyCustomization/EnemyCustomizations/Properties/EventsCustom.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Properties/EventsCustom.cs
@@ -11,6 +11,7 @@ namespace EEC.EnemyCustomizations.Properties
         public EventSetting OnSpawnedEvent { get; set; } = new();
         public EventSetting OnWakeupEvent { get; set; } = new();
         public EventSetting OnDeadEvent { get; set; } = new();
+        public List<uint> LevelLayoutIDs { get; set; } = new();
         public bool TriggerOnBossDeathEventOnDead { get; set; } = false;
 
         public override string GetProcessName()
@@ -34,6 +35,9 @@ namespace EEC.EnemyCustomizations.Properties
 
         public void OnSpawned(EnemyAgent agent)
         {
+            if (LevelLayoutIDs.Count > 0 && !LevelLayoutIDs.Contains(RundownManager.ActiveExpedition.LevelLayoutData))
+                return;
+
             if (OnSpawnedEvent?.Enabled ?? false)
             {
                 OnSpawnedEvent.FireEvents();

--- a/ExtraEnemyCustomization/EnemyCustomizations/Shooters/Handlers/ShooterDistSettingRoutine.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Shooters/Handlers/ShooterDistSettingRoutine.cs
@@ -14,8 +14,10 @@ namespace EEC.EnemyCustomizations.Shooters.Handlers
         public EAB_ProjectileShooter EAB_Shooter;
         public ShooterFireCustom.FireSetting[] FireSettings;
 
-        private ShooterFireCustom.FireSetting _currentSetting = null;
+        private ShooterFireCustom.FireSetting _currentSetting;
         private static readonly WaitForSeconds _yielder = WaitFor.Seconds[0.125f];
+
+        public ShooterDistSettingRoutine(ShooterFireCustom.FireSetting startSetting = null) => _currentSetting = startSetting;
 
         public IEnumerator Routine()
         {
@@ -23,14 +25,15 @@ namespace EEC.EnemyCustomizations.Shooters.Handlers
             {
                 yield return _yielder;
 
-                if (EAB_Shooter.m_owner.Locomotion.CurrentStateEnum == Enemies.ES_StateEnum.ShooterAttack)
+                var stateEnum = EAB_Shooter.m_owner.Locomotion.CurrentStateEnum;
+                if (stateEnum == Enemies.ES_StateEnum.ShooterAttack || stateEnum == Enemies.ES_StateEnum.ShooterAttackFlyer)
                     continue;
 
                 if (!EAB_Shooter.m_owner.AI.IsTargetValid)
                     continue;
 
                 var distance = EAB_Shooter.m_owner.AI.Target.m_distance;
-                var newSetting = FireSettings.FirstOrDefault(x => x.FromDistance <= distance);
+                var newSetting = FireSettings.First(x => x.FromDistance <= distance);
                 if (newSetting != _currentSetting)
                 {
                     newSetting.ApplyToEAB(EAB_Shooter, DefaultValue);

--- a/ExtraEnemyCustomization/EntryPoint.cs
+++ b/ExtraEnemyCustomization/EntryPoint.cs
@@ -18,7 +18,7 @@ namespace EEC
     //TODO: - Patrolling Hibernation : Too many works to do with this one, this is one of the long term goal
     //TODO: Refactor the CustomBase to support Phase Setting
 
-    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.14")]
+    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.15")]
     [BepInProcess("GTFO.exe")]
     [BepInDependency(MTFOUtil.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("GTFO.InjectLib", BepInDependency.DependencyFlags.HardDependency)]

--- a/wikifiles/EEC Documentation/With Comments/Property.jsonc
+++ b/wikifiles/EEC Documentation/With Comments/Property.jsonc
@@ -61,6 +61,7 @@
           }
         ]
       },
+      "LevelLayoutIDs": [], // Which levels to apply to? Empty applies to all levels. Use the main layout ID for the level(s).
       "TriggerOnBossDeathEventOnDead": true //Trigger SpawnedZone's OnBossDeathEvent?
     }
   ],


### PR DESCRIPTION
- Added LevelLayoutIDs field to EventsCustom to restrict events to specific levels.
- Fixed ShooterFireCustom not applying on enemies that had just woken up.

Dev notes:

- Added in a check for the flyer enum in the ShooterFireCustom routine for full coverage, but probably doesn't fix the issue as per Amor's tests.