### PR TITLE
v1.8.21

### DIFF
--- a/ExtraEnemyCustomization/CustomAbilities/Explosion/ExplosionManager.cs
+++ b/ExtraEnemyCustomization/CustomAbilities/Explosion/ExplosionManager.cs
@@ -1,4 +1,5 @@
-﻿using AK;
+﻿using Agents;
+using AK;
 using EEC.Events;
 using Player;
 using SNetwork;
@@ -12,12 +13,16 @@ namespace EEC.CustomAbilities.Explosion
         public static readonly Color FlashColor = new(1, 0.2f, 0, 1);
 
         internal static ExplosionSync Sync { get; private set; } = new();
+        internal static ExplosionAgentSync AgentSync { get; private set; } = new();
 
         private static bool _usingLightFlash = true;
+        private static int _hostMask = 0;
+        private static int _hostOnlyMask = 0;
 
         static ExplosionManager()
         {
             Sync.Setup();
+            AgentSync.Setup();
             AssetEvents.AllAssetLoaded += AssetEvents_AllAssetLoaded;
         }
 
@@ -25,11 +30,32 @@ namespace EEC.CustomAbilities.Explosion
         {
             ExplosionEffectPooling.Initialize();
             _usingLightFlash = Configuration.ShowExplosionEffect;
+            _hostOnlyMask = LayerManager.MASK_EXPLOSION_TARGETS;
+            _hostMask = LayerManager.MASK_EXPLOSION_TARGETS & ~LayerMask.GetMask("PlayerSynced");
         }
 
         public static void DoExplosion(ExplosionData data)
         {
             Sync.Send(data);
+        }
+
+        public static void DoExplosion(ExplosionAgentData data)
+        {
+            AgentSync.Send(data);
+        }
+
+        public static void DoLocalExplosion(ExplosionData data)
+        {
+            Internal_TriggerExplosion(
+                data.position,
+                data.lightColor,
+                data.damage,
+                data.enemyMulti,
+                data.minRange,
+                data.maxRange,
+                data.enemyMinRange,
+                data.enemyMaxRange
+                );
         }
 
         internal static void Internal_TriggerExplosion(Vector3 position, Color lightColor, float damage, float enemyMulti, float minRange, float maxRange, float enemyMinRange, float enemyMaxRange)
@@ -39,10 +65,47 @@ namespace EEC.CustomAbilities.Explosion
             if (_usingLightFlash)
                 LightFlash(position, maxRange, lightColor);
 
-            if (!SNet.IsMaster)
+            if (SNet.IsMaster)
+                TriggerHostExplosion(position, damage, enemyMulti, minRange, maxRange, enemyMinRange, enemyMaxRange, _hostMask);
+            else
+                TriggerClientExplosion(position, damage, minRange, maxRange);
+        }
+
+        internal static void Internal_TriggerHostOnlyExplosion(Vector3 position, Color lightColor, float damage, float enemyMulti, float minRange, float maxRange, float enemyMinRange, float enemyMaxRange)
+        {
+            CellSound.Post(EVENTS.STICKYMINEEXPLODE, position);
+
+            if (_usingLightFlash)
+                LightFlash(position, maxRange, lightColor);
+
+            if (SNet.IsMaster)
+                TriggerHostExplosion(position, damage, enemyMulti, minRange, maxRange, enemyMinRange, enemyMaxRange, _hostOnlyMask);
+        }
+
+        private static void TriggerClientExplosion(Vector3 position, float damage, float minRange, float maxRange)
+        {
+            var target = PlayerManager.GetLocalPlayerAgent();
+            if (target == null) return;
+
+            Vector3 targetPosition = target.EyePosition;
+            var distance = Vector3.Distance(position, targetPosition);
+            if (Physics.Linecast(position, targetPosition, out RaycastHit hit, LayerManager.MASK_EXPLOSION_BLOCKERS))
                 return;
 
-            var targets = Physics.OverlapSphere(position, Math.Max(maxRange, enemyMaxRange), LayerManager.MASK_EXPLOSION_TARGETS);
+            float newDamage = CalcRangeDamage(damage, distance, minRange, maxRange);
+            if (newDamage == 0) return;
+
+            Logger.Verbose($"Explosive damage: {newDamage} out of max: {damage}, Dist: {distance}, min: {minRange}, max: {maxRange}");
+            var damageable = target.GetComponent<Dam_SyncedDamageBase>();
+            if (newDamage < 0)
+                ExplosionHeal(damageable, target, -newDamage);
+            else
+                damageable.ExplosionDamage(newDamage, position, Vector3.up * 1000);
+        }
+
+        private static void TriggerHostExplosion(Vector3 position, float damage, float enemyMulti, float minRange, float maxRange, float enemyMinRange, float enemyMaxRange, int mask)
+        {
+            var targets = Physics.OverlapSphere(position, Math.Max(maxRange, enemyMaxRange), mask);
             if (targets.Count < 1)
                 return;
 
@@ -117,8 +180,12 @@ namespace EEC.CustomAbilities.Explosion
 
         private static void ExplosionHeal(IDamageable damageable, Agents.Agent? agent, float heal)
         {
-            if (agent == null) return;
+            if (agent != null)
+                ExplosionHeal(damageable.Cast<Dam_SyncedDamageBase>(), agent, heal);
+        }
 
+        private static void ExplosionHeal(Dam_SyncedDamageBase damageable, Agents.Agent agent, float heal)
+        {
             var syncedBase = damageable.Cast<Dam_SyncedDamageBase>();
             syncedBase.SendSetHealth(syncedBase.Health + heal);
         }
@@ -164,6 +231,19 @@ namespace EEC.CustomAbilities.Explosion
     public struct ExplosionData
     {
         public Vector3 position;
+        public float damage;
+        public float enemyMulti;
+        public float minRange;
+        public float maxRange;
+        public float enemyMinRange;
+        public float enemyMaxRange;
+        public Color lightColor;
+    }
+
+    public struct ExplosionAgentData
+    {
+        public pAgent agent;
+        public bool useRagdoll;
         public float damage;
         public float enemyMulti;
         public float minRange;

--- a/ExtraEnemyCustomization/CustomAbilities/Explosion/ExplosionSync.cs
+++ b/ExtraEnemyCustomization/CustomAbilities/Explosion/ExplosionSync.cs
@@ -9,7 +9,22 @@ namespace EEC.CustomAbilities.Explosion
         protected override void Receive(ExplosionData packet)
         {
             Logger.Verbose($"Explosion Received: [{packet.position}] {packet.damage} {packet.enemyMulti} {packet.minRange} {packet.maxRange}");
-            ExplosionManager.Internal_TriggerExplosion(packet.position, packet.lightColor, packet.damage, packet.enemyMulti, packet.minRange, packet.maxRange, packet.enemyMinRange, packet.enemyMaxRange);
+            ExplosionManager.Internal_TriggerHostOnlyExplosion(packet.position, packet.lightColor, packet.damage, packet.enemyMulti, packet.minRange, packet.maxRange, packet.enemyMinRange, packet.enemyMaxRange);
+        }
+    }
+
+    internal sealed class ExplosionAgentSync : SyncedEvent<ExplosionAgentData>
+    {
+        public override string GUID => "EXPA";
+
+        protected override void Receive(ExplosionAgentData packet)
+        {
+            if (!packet.agent.TryGet(out var agent)) return;
+
+            var position = agent.EyePosition;
+            if (packet.useRagdoll)
+                agent.GetRagdollPosition(ref position);
+            ExplosionManager.Internal_TriggerExplosion(position, packet.lightColor, packet.damage, packet.enemyMulti, packet.minRange, packet.maxRange, packet.enemyMinRange, packet.enemyMaxRange);
         }
     }
 }

--- a/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/CustomProjectile.cs
+++ b/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/CustomProjectile.cs
@@ -43,8 +43,8 @@ namespace EEC.CustomSettings.CustomProjectiles
 
         public void DoCollisionEffect(ProjectileBase proj, Vector3 projectilePosition, PlayerAgent player = null)
         {
-            if (SNet.IsMaster && (Explosion?.Enabled ?? false))
-                Explosion.DoExplode(projectilePosition);
+            if (Explosion?.Enabled ?? false)
+                Explosion.DoLocalExplode(projectilePosition);
 
             if (player == null || !player.IsLocallyOwned)
                 return;

--- a/ExtraEnemyCustomization/EnemyCustomizations/Abilities/AttackCustoms/ExplosiveAttackCustom.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Abilities/AttackCustoms/ExplosiveAttackCustom.cs
@@ -74,7 +74,7 @@ namespace EEC.EnemyCustomizations.Abilities
                 if (!IsTarget(owner))
                     return;
 
-                ProjectileData.DoExplode(projectile.transform.position);
+                ProjectileData.DoLocalExplode(projectile.transform.position);
                 ProjectileData.TryKillInflictor(owner);
             }
             else if (projectile.TryGetOwnerEnemyDataID(out var ownerID))
@@ -82,7 +82,7 @@ namespace EEC.EnemyCustomizations.Abilities
                 if (!IsTarget(ownerID))
                     return;
 
-                ProjectileData.DoExplode(projectile.transform.position);
+                ProjectileData.DoLocalExplode(projectile.transform.position);
             }
         }
 

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBase.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBase.cs
@@ -58,16 +58,16 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
         #region ABILITY CALLER
 
-        public void TriggerSync(ushort enemyID)
+        public void TriggerSync(ushort enemyID, bool useClientPos)
         {
-            EnemyAbilityManager.SendEvent(SyncID, enemyID, AbilityPacketType.DoTrigger);
+            EnemyAbilityManager.SendEvent(SyncID, enemyID, AbilityPacketType.DoTrigger, useClientPos);
         }
 
-        public void Trigger(ushort enemyID)
+        public void Trigger(ushort enemyID, bool useClientPos)
         {
             if (TryGetBehaviour(enemyID, out var behaviour))
             {
-                behaviour.DoTrigger();
+                behaviour.DoTrigger(useClientPos);
             }
         }
 
@@ -80,7 +80,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         {
             foreach (var behaviour in _behaviours)
             {
-                behaviour.DoTrigger();
+                behaviour.DoTrigger(useClientPos: false);
             }
         }
 

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
@@ -255,14 +255,14 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
             }
         }
 
-        public void DoTriggerSync()
+        public void DoTriggerSync(bool useClientPos)
         {
-            EnemyAbilityManager.SendEvent(BaseAbility.SyncID, Agent.GlobalID, AbilityPacketType.DoTrigger);
+            EnemyAbilityManager.SendEvent(BaseAbility.SyncID, Agent.GlobalID, AbilityPacketType.DoTrigger, useClientPos);
         }
 
-        public void DoTrigger()
+        public void DoTrigger(bool useClientPos)
         {
-            DoEnter();
+            DoEnter(useClientPos);
         }
 
         public void DoEnterSync()
@@ -270,7 +270,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
             EnemyAbilityManager.SendEvent(BaseAbility.SyncID, Agent.GlobalID, AbilityPacketType.DoTrigger);
         }
 
-        public void DoEnter()
+        public void DoEnter(bool useClientPos)
         {
             if (IsMasterOnlyAndClient)
                 return;
@@ -279,7 +279,10 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                 return;
 
             Executing = true;
-            OnEnter();
+            if (useClientPos)
+                OnEnterUseClientPos();
+            else
+                OnEnter();
         }
 
         public void DoExitSync()
@@ -333,6 +336,11 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
         protected virtual void OnEnter()
         {
+        }
+
+        protected virtual void OnEnterUseClientPos()
+        {
+            OnEnter();
         }
 
         protected virtual void OnAbilityLazyUpdate()

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/IAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/IAbility.cs
@@ -12,13 +12,13 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
         void Unload();
 
-        void TriggerSync(EnemyAgent agent) => TriggerSync(agent.GlobalID);
+        void TriggerSync(EnemyAgent agent, bool clientPos = false) => TriggerSync(agent.GlobalID, clientPos);
 
-        void TriggerSync(ushort enemyID);
+        void TriggerSync(ushort enemyID, bool clientPos = false);
 
-        void Trigger(EnemyAgent agent) => Trigger(agent.GlobalID);
+        void Trigger(EnemyAgent agent, bool clientPos) => Trigger(agent.GlobalID, clientPos);
 
-        void Trigger(ushort enemyID);
+        void Trigger(ushort enemyID, bool clientPos);
 
         void TriggerAllSync();
 

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ChainedAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ChainedAbility.cs
@@ -55,6 +55,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         private bool _waitingEndTimer = false;
         private bool _allFinished = false;
         private bool _forceExit = false;
+        private bool _useClientPos = false;
 
         protected override void OnSetup()
         {
@@ -77,6 +78,12 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
             
         }
 
+        protected override void OnEnterUseClientPos()
+        {
+            OnEnter();
+            _useClientPos = true;
+        }
+
         protected override void OnEnter()
         {
             foreach (var block in _blockBehaviours)
@@ -87,6 +94,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
 
             _waitingEndTimer = false;
             _forceExit = true;
+            _useClientPos = false;
         }
 
         protected override void OnUpdate()
@@ -99,7 +107,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                 {
                     if (block.TriggerTimer.TickAndCheckDone())
                     {
-                        block.AbSetting.Ability.TriggerSync(Agent);
+                        block.AbSetting.Ability.TriggerSync(Agent, _useClientPos);
                         block.Triggered = true;
                     }
                     else

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ExplosionAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/ExplosionAbility.cs
@@ -30,7 +30,17 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
         public override bool AllowEABAbilityWhileExecuting => true;
         public override bool IsHostOnlyBehaviour => true;
 
+        protected override void OnEnterUseClientPos()
+        {
+            DoExplosion(true);
+        }
+
         protected override void OnEnter()
+        {
+            DoExplosion(false);
+        }
+
+        private void DoExplosion(bool useClientPos)
         {
             if (Agent.WasCollected)
             {
@@ -50,32 +60,9 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                 counter.Count++;
             }
 
-            var position = Agent.EyePosition;
-            if (Ability.UseRagdollPosition)
-            {
-                GetRagdollPosition(ref position);
-            }
-            Ability.DoExplode(Agent.CourseNode, position);
+            Ability.DoExplode(Agent, Ability.UseRagdollPosition, useClientPos);
             Ability.TryKillInflictor(Agent);
             DoExit();
-        }
-
-        private void GetRagdollPosition(ref Vector3 position)
-        {
-            if (Agent.Alive)
-                return;
-
-            if (Agent.RagdollInstance is null)
-                return;
-
-            if (Agent.EnemyMovementData.LocomotionDead != Enemies.ES_StateEnum.Dead)
-                return;
-
-            var bodyData = Agent.RagdollInstance.GetComponentInChildren<EnemyRagdollBodyData>();
-            if (bodyData is null)
-                return;
-
-            position = bodyData.transform.position;
         }
     }
 

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Base/EnemyAbilityCustomBase.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Base/EnemyAbilityCustomBase.cs
@@ -52,14 +52,14 @@ namespace EEC.EnemyCustomizations.EnemyAbilities
             OnSpawnedPost(agent);
         }
 
-        public static void DoTriggerDelayed(IAbility ability, EnemyAgent agent, float delay)
+        public static void DoTriggerDelayed(IAbility ability, EnemyAgent agent, float delay, bool useClientPos)
         {
             Task.Factory.StartNew(async () =>
             {
                 await Task.Delay((int)Math.Round(delay * 1000.0f));
                 ThreadDispatcher.Dispatch(() =>
                 {
-                    ability?.TriggerSync(agent);
+                    ability?.TriggerSync(agent, useClientPos);
                 });
             });
         }

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/DeathAbilityCustom.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/DeathAbilityCustom.cs
@@ -21,7 +21,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities
                 if (!ab.AllowedMode.IsMatch(agent))
                     return;
 
-                DoTriggerDelayed(ab.Ability, agent, ab.Delay);
+                DoTriggerDelayed(ab.Ability, agent, ab.Delay, useClientPos: true);
             }
         }
     }

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/EnemyAbilityManager.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/EnemyAbilityManager.cs
@@ -86,7 +86,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities
             _abilityIDLookup.Clear();
         }
 
-        public static void SendEvent(ushort syncID, ushort enemyID, AbilityPacketType type)
+        public static void SendEvent(ushort syncID, ushort enemyID, AbilityPacketType type, bool useClientPos = false)
         {
             if (!SNet.IsMaster)
                 return;
@@ -94,6 +94,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities
             _abilityEvent.Send(new AbilityEvent.Packet()
             {
                 Type = type,
+                UseClientPos = useClientPos,
                 SyncID = syncID,
                 EnemyID = enemyID,
             });
@@ -110,7 +111,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities
                         break;
 
                     case AbilityPacketType.DoTrigger:
-                        ability.Trigger(packet.EnemyID);
+                        ability.Trigger(packet.EnemyID, packet.UseClientPos);
                         break;
 
                     case AbilityPacketType.DoExitAll:
@@ -140,6 +141,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities
         public struct Packet
         {
             public AbilityPacketType Type;
+            public bool UseClientPos;
             public ushort SyncID;
             public ushort EnemyID;
         }

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Handlers/BehaviourUpdateRoutine.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Handlers/BehaviourUpdateRoutine.cs
@@ -81,7 +81,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Handlers
                     _cooldownTimer.Reset(Setting.Cooldown.Cooldown);
             }
 
-            Behaviour.DoTriggerSync();
+            Behaviour.DoTriggerSync(useClientPos: false);
         }
 
         private bool CheckAllowedModeCondition()

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/LimbDestroyedAbilityCustom.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/LimbDestroyedAbilityCustom.cs
@@ -45,7 +45,7 @@ namespace EEC.EnemyCustomizations.EnemyAbilities
                     if (!setting.AllowedMode.IsMatch(agent))
                         return;
 
-                    DoTriggerDelayed(setting.Ability, agent, setting.Delay);
+                    DoTriggerDelayed(setting.Ability, agent, setting.Delay, useClientPos: true);
                 }));
             }
         }

--- a/ExtraEnemyCustomization/EnemyCustomizations/Shared/Extensions/ExplosionExtension.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Shared/Extensions/ExplosionExtension.cs
@@ -29,23 +29,45 @@ namespace EEC.EnemyCustomizations.Shared
             }
         }
 
-        public static void DoExplode(this IExplosionSetting setting, Agent from)
+        public static void DoExplode(this IExplosionSetting setting, Agent from, bool useRagdoll = false, bool useClientPos = true)
         {
             var position = from.EyePosition;
-            MakeExplosion(setting, position);
+            if (useRagdoll)
+                from.GetRagdollPosition(ref position);
+            if (useClientPos)
+                MakeExplosion(setting, from, useRagdoll);
+            else
+                MakeExplosion(setting, position);
             MakeNoise(setting, from.CourseNode, position);
         }
 
-        public static void DoExplode(this IExplosionSetting setting, Vector3 position)
+        public static void DoLocalExplode(this IExplosionSetting setting, Vector3 position)
         {
-            MakeExplosion(setting, position);
-            TryMakeNoise(setting, position);
+            MakeLocalExplosion(setting, position);
+            if (SNetwork.SNet.IsMaster)
+                TryMakeNoise(setting, position);
         }
 
-        public static void DoExplode(this IExplosionSetting setting, AIG_CourseNode node, Vector3 position)
+        public static void MakeExplosion(this IExplosionSetting setting, Agent agent, bool useRagdoll = false)
         {
-            MakeExplosion(setting, position);
-            MakeNoise(setting, node, position);
+            var maxDamage = setting.Damage.GetAbsValue(PlayerData.MaxHealth);
+            if (maxDamage != 0.0f)
+            {
+                var data = new ExplosionAgentData()
+                {
+                    useRagdoll = useRagdoll,
+                    damage = maxDamage,
+                    enemyMulti = setting.EnemyDamageMulti,
+                    minRange = setting.MinRange,
+                    maxRange = setting.MaxRange,
+                    enemyMinRange = setting.EnemyMinRange.GetAbsValue(setting.MinRange),
+                    enemyMaxRange = setting.EnemyMaxRange.GetAbsValue(setting.MaxRange),
+                    lightColor = setting.LightColor
+                };
+                data.agent.Set(agent);
+
+                ExplosionManager.DoExplosion(data);
+            }
         }
 
         public static void MakeExplosion(this IExplosionSetting setting, Vector3 position)
@@ -54,6 +76,25 @@ namespace EEC.EnemyCustomizations.Shared
             if (maxDamage != 0.0f)
             {
                 ExplosionManager.DoExplosion(new ExplosionData()
+                {
+                    position = position,
+                    damage = maxDamage,
+                    enemyMulti = setting.EnemyDamageMulti,
+                    minRange = setting.MinRange,
+                    maxRange = setting.MaxRange,
+                    enemyMinRange = setting.EnemyMinRange.GetAbsValue(setting.MinRange),
+                    enemyMaxRange = setting.EnemyMaxRange.GetAbsValue(setting.MaxRange),
+                    lightColor = setting.LightColor
+                });
+            }
+        }
+
+        public static void MakeLocalExplosion(this IExplosionSetting setting, Vector3 position)
+        {
+            var maxDamage = setting.Damage.GetAbsValue(PlayerData.MaxHealth);
+            if (maxDamage != 0.0f)
+            {
+                ExplosionManager.DoLocalExplosion(new ExplosionData()
                 {
                     position = position,
                     damage = maxDamage,

--- a/ExtraEnemyCustomization/EntryPoint.cs
+++ b/ExtraEnemyCustomization/EntryPoint.cs
@@ -18,7 +18,7 @@ namespace EEC
     //TODO: - Patrolling Hibernation : Too many works to do with this one, this is one of the long term goal
     //TODO: Refactor the CustomBase to support Phase Setting
 
-    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.20")]
+    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.21")]
     [BepInProcess("GTFO.exe")]
     [BepInDependency(MTFOUtil.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("GTFO.InjectLib", BepInDependency.DependencyFlags.HardDependency)]

--- a/ExtraEnemyCustomization/Extensions/AgentExtension.cs
+++ b/ExtraEnemyCustomization/Extensions/AgentExtension.cs
@@ -38,5 +38,13 @@ namespace EEC
             result = null;
             return false;
         }
+
+        public static void GetRagdollPosition(this Agent agent, ref UnityEngine.Vector3 position)
+        {
+            if (!agent.TryCastToEnemyAgent(out var enemy))
+                return;
+
+            enemy.GetRagdollPosition(ref position);
+        }
     }
 }

--- a/ExtraEnemyCustomization/Extensions/EnemyAgentExtension.cs
+++ b/ExtraEnemyCustomization/Extensions/EnemyAgentExtension.cs
@@ -1,4 +1,5 @@
-﻿using AIGraph;
+﻿using Agents;
+using AIGraph;
 using EEC.Managers.Properties;
 using EEC.Utils;
 using Enemies;
@@ -74,6 +75,24 @@ namespace EEC
                 return null;
 
             return node;
+        }
+
+        public static void GetRagdollPosition(this EnemyAgent agent, ref UnityEngine.Vector3 position)
+        {
+            if (agent.Alive)
+                return;
+
+            if (agent.RagdollInstance is null)
+                return;
+
+            if (agent.EnemyMovementData.LocomotionDead != Enemies.ES_StateEnum.Dead)
+                return;
+
+            var bodyData = agent.RagdollInstance.GetComponentInChildren<EnemyRagdollBodyData>();
+            if (bodyData is null)
+                return;
+
+            position = bodyData.transform.position;
         }
 
         public static bool CanUseAbilities(this EnemyAgent agent)


### PR DESCRIPTION
Explosion damage is now handled on client in most instances.

Specifically, projectile explosions, tongue explosive attacks, and enemy death explosions are now tied to where the attack is on client side. Explosions done by other means, such as BehaviourAbilityCustom, are done on host side since the validity checks are done there and causes not great game behavior (like walking backwards preventing all damage).

Because I need information from the triggering ability rather than ExplosiveAttackCustom, I kinda had to jury-rig this `useClientPos` packet information. It's not very robust or modular, but I don't foresee many changes to the system so I focused on making a working solution above refactoring.