### PR TITLE
1.8.22

### DIFF
--- a/ExtraEnemyCustomization/CustomAbilities/EMP/EMPHandlerBase.cs
+++ b/ExtraEnemyCustomization/CustomAbilities/EMP/EMPHandlerBase.cs
@@ -95,7 +95,7 @@ namespace EEC.CustomAbilities.EMP
         public void Tick(bool isEMPD)
         {
             if (_destroyed) return;
-            if (isEMPD && _state == EMPState.On)
+            if (isEMPD && _state == EMPState.On && _deviceState == DeviceState.On)
             {
                 OnEMPStart();
                 float delay = GetRandomDelay(MinDelay, MaxDelay);

--- a/ExtraEnemyCustomization/EnemyCustomizations/Models/Handlers/MarkerTextHandler.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Models/Handlers/MarkerTextHandler.cs
@@ -20,6 +20,7 @@ namespace EEC.EnemyCustomizations.Models.Handlers
         private bool[] _hasFormat = null;
         private bool _shouldUpdateRainbow = false;
         private Color _rainbow;
+        private IEnumerator _updateLoop;
 
         private static readonly MarkerFormatText[] _valuesOfEnum = null;
         private static readonly string[] _formatString = null;
@@ -92,15 +93,20 @@ namespace EEC.EnemyCustomizations.Models.Handlers
                 Destroy(this);
             }
         }
-
+        
         private void OnEnable()
         {
-            StopAllCoroutines();
+            _updateLoop = UpdateText();
+            InitializeText();
+        }
+
+        private void Update()
+        {
             if (_shouldUpdateRainbow)
             {
-                this.StartCoroutine(GamingMoment());
+                _rainbow = Color.HSVToRGB(Mathf.Repeat(Clock.ExpeditionProgressionTime, 1.0f), 1.0f, 1.0f);
             }
-            this.StartCoroutine(UpdateText());
+            _updateLoop.MoveNext();
         }
 
         [HideFromIl2Cpp]
@@ -108,32 +114,26 @@ namespace EEC.EnemyCustomizations.Models.Handlers
         {
             var oldText = string.Empty;
             var textBuilder = new StringBuilder(_baseText);
+            var lastHealth = 0f;
 
             while (true)
             {
                 NetworkManager.EnemyHealthState.TryGetState(Agent.GlobalID, out var healthState);
                 var maxHealth = healthState.maxHealth;
                 var health = healthState.health;
+                if (lastHealth == health && !_hasFormat[(int)MarkerFormatText.GAMING])
+                {
+                    yield return _updateYielder;
+                    continue;
+                }
+                lastHealth = health;
 
                 for (int i = 1 /*Skips None*/; i < _valuesOfEnum.Length; i++)
                 {
                     if (!_hasFormat[i])
                         continue;
 
-                    string replace = (MarkerFormatText)i switch
-                    {
-                        MarkerFormatText.None => string.Empty,
-                        MarkerFormatText.NAME => string.Empty,
-                        MarkerFormatText.HP => health.ToString("0.00"),
-                        MarkerFormatText.HP_ROUND => Mathf.RoundToInt(health).ToString(),
-                        MarkerFormatText.HP_MAX => maxHealth.ToString("0.00"),
-                        MarkerFormatText.HP_MAX_ROUND => Mathf.RoundToInt(maxHealth).ToString(),
-                        MarkerFormatText.HP_PERCENT => (health / maxHealth * 100.0f).ToString("0.00"),
-                        MarkerFormatText.HP_PERCENT_ROUND => Mathf.RoundToInt(health / maxHealth * 100.0f).ToString(),
-                        MarkerFormatText.HP_BAR => Worker.BuildString(maxHealth, health),
-                        MarkerFormatText.GAMING => ColorUtility.ToHtmlStringRGB(_rainbow),
-                        _ => string.Empty,
-                    };
+                    string replace = GetFormatText((MarkerFormatText)i, health, maxHealth);
 
                     if (!string.IsNullOrEmpty(replace))
                     {
@@ -155,14 +155,45 @@ namespace EEC.EnemyCustomizations.Models.Handlers
             }
         }
 
-        [HideFromIl2Cpp]
-        private IEnumerator GamingMoment()
+        private void InitializeText()
         {
-            while (true)
+            NetworkManager.EnemyHealthState.TryGetState(Agent.GlobalID, out var healthState);
+            var maxHealth = healthState.maxHealth;
+            var health = healthState.health;
+            StringBuilder textBuilder = new(_baseText);
+
+            for (int i = 1 /*Skips None*/; i < _valuesOfEnum.Length; i++)
             {
-                _rainbow = Color.HSVToRGB(Mathf.Repeat(Clock.ExpeditionProgressionTime, 1.0f), 1.0f, 1.0f);
-                yield return null;
+                if (!_hasFormat[i])
+                    continue;
+
+                string replace = GetFormatText((MarkerFormatText)i, health, maxHealth);
+
+                if (!string.IsNullOrEmpty(replace))
+                {
+                    textBuilder.Replace(_formatString[i], replace);
+                }
             }
+
+            Marker.SetTitle(textBuilder.ToString());
+        }
+
+        private string GetFormatText(MarkerFormatText format, float health, float maxHealth)
+        {
+             return format switch
+             {
+                 MarkerFormatText.None => string.Empty,
+                 MarkerFormatText.NAME => string.Empty,
+                 MarkerFormatText.HP => health.ToString("0.00"),
+                 MarkerFormatText.HP_ROUND => Mathf.RoundToInt(health).ToString(),
+                 MarkerFormatText.HP_MAX => maxHealth.ToString("0.00"),
+                 MarkerFormatText.HP_MAX_ROUND => Mathf.RoundToInt(maxHealth).ToString(),
+                 MarkerFormatText.HP_PERCENT => (health / maxHealth * 100.0f).ToString("0.00"),
+                 MarkerFormatText.HP_PERCENT_ROUND => Mathf.RoundToInt(health / maxHealth * 100.0f).ToString(),
+                 MarkerFormatText.HP_BAR => Worker.BuildString(maxHealth, health),
+                 MarkerFormatText.GAMING => ColorUtility.ToHtmlStringRGB(_rainbow),
+                 _ => string.Empty,
+             };
         }
 
         private void OnDestroy()

--- a/ExtraEnemyCustomization/Networking/NetworkManager.cs
+++ b/ExtraEnemyCustomization/Networking/NetworkManager.cs
@@ -81,6 +81,7 @@ namespace EEC.Networking
         private static void EnemyDespawn(EnemyAgent agent)
         {
             EnemyAgentModeState.Deregister(agent.GlobalID);
+            EnemyHealthState.Deregister(agent.GlobalID);
         }
     }
 }


### PR DESCRIPTION
- Fixed a rare case where triggering an EMP as a previous one ended could disable a device permanently.
- Fixed custom enemy markers breaking after a checkpoint load until the enemy took damage.

Dev notes:
- Cleaned up the marker code a little bit - it didn't really need coroutines since it just used them as de-facto update functions.
  - Also "fixed" custom markers not being correct immediately when they pop in, but it's not very noticeable anyway.