### PR TITLE
Fix StandStill state issues

### DIFF
--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/Base/AbilityBehaviour.cs
@@ -69,6 +69,22 @@ namespace EEC.EnemyCustomizations.EnemyAbilities.Abilities
                 if (StandStill)
                 {
                     _prevState = Agent.Locomotion.CurrentStateEnum;
+                    switch (_prevState)
+                    {
+                        case ES_StateEnum.Hitreact:
+                        case ES_StateEnum.HitReactFlyer:
+                            if (Agent.Locomotion.Hitreact.CurrentReactionType == ES_HitreactType.ToDeath)
+                                return;
+                            break;
+                        case ES_StateEnum.Dead:
+                        case ES_StateEnum.DeadFlyer:
+                        case ES_StateEnum.DeadSquidBoss:
+                        case ES_StateEnum.ScoutScream:
+                            return;
+                        default:
+                            break;
+                    }
+
                     _navAgent.isStopped = true;
                     _navAgent.velocity = Vector3.zero;
                     Agent.Locomotion.ChangeState(ES_StateEnum.StandStill);


### PR DESCRIPTION
Fixes cases where an enemy could enter stand still, exiting important states.

Most notably, an enemy could enter StandStill during Hitreact to death, which prevented them from dying and left them stuck in the world forever.