### PR TITLE
Bleed FX and Global changes, live edit config

### DIFF
--- a/ExtraEnemyCustomization/Configs/GlobalConfig.cs
+++ b/ExtraEnemyCustomization/Configs/GlobalConfig.cs
@@ -27,9 +27,11 @@ namespace EEC.Configs
         #region Bleeding
 
         [JsonPropertyName("Bleeding.UseMediToStop")]
-        public bool CanMediStopBleeding { get; set; } = false;
+        public bool CanMediStopBleeding { get; set; } = true;
         [JsonPropertyName("Bleeding.StopOnDown")]
-        public bool CanDownStopBleeding { get; set; } = false;
+        public bool CanDownStopBleeding { get; set; } = true;
+        [JsonPropertyName("Bleeding.DoAimPunch")]
+        public bool CanBleedAimPunch { get; set; } = false;
 
         #endregion Bleeding
 

--- a/ExtraEnemyCustomization/Configuration.cs
+++ b/ExtraEnemyCustomization/Configuration.cs
@@ -2,6 +2,7 @@
 using BepInEx.Configuration;
 using EEC.Managers.Assets;
 using EEC.Patches.Handlers;
+using GTFO.API.Utilities;
 using System;
 using System.IO;
 
@@ -18,10 +19,12 @@ namespace EEC
         //USER CONFIGS
         public static bool ShowMarkerText { get; private set; }
         public static bool ShowMarkerDistance { get; private set; }
+        public static bool PlayDialogueFromBleed { get; private set; }
         public static bool ShowExplosionEffect { get; private set; }
         public static ShitpostType ShitpostType { get; private set; }
         private static ConfigEntry<bool> _showMarkerText;
         private static ConfigEntry<bool> _showMarkerDistance;
+        private static ConfigEntry<bool> _playDialogueFromBleed;
         private static ConfigEntry<bool> _showExplosionEffect;
         private static ConfigEntry<ShitpostType> _shitpostType;
 
@@ -46,6 +49,7 @@ namespace EEC
         private static ConfigEntry<bool> _profiler;
 
         private static ConfigFile _currentContext;
+        public static event Action? OnReload;
 
         public static bool CanShitpostOf(ShitpostType type)
         {
@@ -76,6 +80,9 @@ namespace EEC
                 _ = BindConfigVersion(config);
             }
             BindAll(config);
+
+            var liveEditListener = LiveEdit.CreateListener(Paths.ConfigPath, "EEC.cfg", false);
+            liveEditListener.FileChanged += OnLiveEdit;
         }
 
         public static void BindAll(ConfigFile context)
@@ -84,29 +91,47 @@ namespace EEC
 
             _showMarkerText = BindUserConfig("Marker Text", "Display Enemy Marker Texts? (if set by rundown devs)", true);
             _showMarkerDistance = BindUserConfig("Marker Distance", "Display Enemy Marker Distance? (if set by rundown devs)", true);
+            _playDialogueFromBleed = BindUserConfig("Bleed Dialogue", "Trigger damage taken dialogue when damaged by bleed? (Audible to all players)", false);
             _showExplosionEffect = BindUserConfig("Explosion Flash", "(Accessibility) Display Light flash effect for explosion abilities?", true);
             _shitpostType = BindUserConfig("Shitposting", "Shitpost mode use comma to enable multiple stuffs", ShitpostType.ForceOff);
-            ShowMarkerText = _showMarkerText.Value;
-            ShowMarkerDistance = _showMarkerDistance.Value;
-            ShowExplosionEffect = _showExplosionEffect.Value;
-            ShitpostType = _shitpostType.Value;
 
             _useLiveEdit = BindRdwDevConfig("Live Edit", "Reload Config when they are edited while in-game", true);
             _linkMTFOHotReload = BindRdwDevConfig("Reload on MTFO HotReload", "Reload Configs when MTFO's HotReload button has pressed?", true);
-            UseLiveEdit = _useLiveEdit.Value;
-            LinkMTFOHotReload = _linkMTFOHotReload.Value;
 
             _useDebugLog = BindLoggingConfig("UseDevMessage", "Using Dev Message for Debugging your config?", false);
             _useVerboseLog = BindLoggingConfig("Verbose", "Using Much more detailed Message for Debugging?", false);
             _assetCacheBehaviour = BindLoggingConfig("Cached Asset Result Output", "How does your cached material/texture result be returned?", AssetCacheManager.OutputType.None);
+
+            _dumpConfig = BindDevConfig("DumpConfig", "Dump Empty Config file?", false);
+            _profiler = BindDevConfig("Profiler", "Show Profiler Info for Spawned Event", false);
+
+            CacheConfigValues();
+        }
+
+        private static void CacheConfigValues()
+        {
+            ShowMarkerText = _showMarkerText.Value;
+            ShowMarkerDistance = _showMarkerDistance.Value;
+            PlayDialogueFromBleed = _playDialogueFromBleed.Value;
+            ShowExplosionEffect = _showExplosionEffect.Value;
+            ShitpostType = _shitpostType.Value;
+
+            UseLiveEdit = _useLiveEdit.Value;
+            LinkMTFOHotReload = _linkMTFOHotReload.Value;
+
             UseDebugLog = _useDebugLog.Value;
             UseVerboseLog = _useVerboseLog.Value;
             AssetCacheBehaviour = _assetCacheBehaviour.Value;
 
-            _dumpConfig = BindDevConfig("DumpConfig", "Dump Empty Config file?", false);
-            _profiler = BindDevConfig("Profiler", "Show Profiler Info for Spawned Event", false);
             DumpConfig = _dumpConfig.Value;
             Profiler = _profiler.Value;
+        }
+
+        private static void OnLiveEdit(LiveEditEventArgs _)
+        {
+            _currentContext.Reload();
+            CacheConfigValues();
+            OnReload?.Invoke();
         }
 
         private static ConfigEntry<int> BindConfigVersion(ConfigFile context)

--- a/ExtraEnemyCustomization/CustomAbilities/Bleed/Inject/Inject_Dam_PlayerDamageLocal_ReceiveFireDamage.cs
+++ b/ExtraEnemyCustomization/CustomAbilities/Bleed/Inject/Inject_Dam_PlayerDamageLocal_ReceiveFireDamage.cs
@@ -1,0 +1,62 @@
+﻿using AK;
+using EEC;
+using EEC.Managers;
+using HarmonyLib;
+using Player;
+using UnityEngine;
+
+namespace ExtraEnemyCustomization.CustomAbilities.Bleed.Inject
+{
+    [HarmonyPatch(typeof(Dam_PlayerDamageLocal), nameof(Dam_PlayerDamageLocal.ReceiveFireDamage))]
+    internal static class Inject_Dam_PlayerDamageLocal_ReceiveFireDamage
+    {
+        // Values pulled from FPSCamera.AddHitReact
+        private const float FLASH_COOLDOWN = 0.3f;
+        private const float MIN_DAMAGE_FLASH = 0.96f;
+        private const float DAMAGE_TO_FLASH_MOD = 1.5f;
+        private const float HURT_VOICELINE_THRESHOLD = 0.3f;
+        private const float VOICELINE_COOLDOWN = 3f;
+
+        private static float _lastFXTime;
+        private static bool Prefix(Dam_PlayerDamageLocal __instance, pSmallDamageData data)
+        {
+            float damage = data.damage.Get(__instance.HealthMax);
+            __instance.OnIncomingDamage(damage, damage);
+
+            if (ConfigManager.Global.CanBleedAimPunch)
+                __instance.Hitreact(damage, Vector3.zero, true, Configuration.PlayDialogueFromBleed);
+            else
+                TryScreenFlash(damage, __instance);
+            return false;
+        }
+
+        // FPSCamera.HitReact modified to remove spring, so bleed cannot prevent normal attack aim punch.
+        private static void TryScreenFlash(float damage, Dam_PlayerDamageLocal __instance)
+        {
+            var time = Clock.Time;
+            if (time <= _lastFXTime) return;
+
+            var owner = __instance.Owner;
+            var camera = owner.FPSCamera;
+            if (Clock.Time <= camera.m_hitreactTimer) return;
+
+            if (Configuration.PlayDialogueFromBleed && time > __instance.m_damageVoiceTimer)
+            {
+                if (__instance.GetHealthRel() < HURT_VOICELINE_THRESHOLD)
+                    PlayerVoiceManager.WantToSayAndStartDialog(owner.CharacterID, EVENTS.PLAY_LOWHEALTHGRUNT01_1A, 99u);
+                else
+                    PlayerVoiceManager.WantToSayAndStartDialog(owner.CharacterID, EVENTS.PLAY_LOWHEALTHGRUNT01_1A, 27u);
+
+                __instance.m_damageVoiceTimer = time + VOICELINE_COOLDOWN;
+            }
+
+            var direction = UnityEngine.Random.onUnitSphere;
+            var forward = Vector3.Dot(direction, camera.m_orgParent.forward);
+            var up = Vector3.Dot(direction, camera.m_orgParent.up) * -1;
+            var right = Vector3.Dot(direction, camera.m_orgParent.right);
+            _lastFXTime = time + FLASH_COOLDOWN;
+            float flashAmount = Math.Min(damage / 2f, MIN_DAMAGE_FLASH) * DAMAGE_TO_FLASH_MOD;
+            camera.m_fpsDamageFeedback.AddDamage(flashAmount, forward, up, right);
+        }
+    }
+}

--- a/ExtraEnemyCustomization/Managers/ConfigManager.cs
+++ b/ExtraEnemyCustomization/Managers/ConfigManager.cs
@@ -49,6 +49,7 @@ namespace EEC.Managers
         private static readonly Dictionary<string, Type> _configFileNameToType = new();
         private static readonly Dictionary<string, Config> _configInstances = new();
         private static readonly IEnumerable<PropertyInfo> _cacheProperties;
+        private static LiveEditListener _liveEdit;
 
         static ConfigManager()
         {
@@ -82,9 +83,30 @@ namespace EEC.Managers
 
             if (UseLiveEdit)
             {
-                var liveEdit = LiveEdit.CreateListener(BasePath, "*.*", true);
-                liveEdit.FileChanged += LiveEdit_FileChanged;
-                liveEdit.StartListen();
+                SetupLiveEdit();
+            }
+
+            Configuration.OnReload += OnConfigReloaded;
+        }
+
+        internal static void OnConfigReloaded()
+        {
+            if (LinkMTFOHotReload != Configuration.LinkMTFOHotReload)
+            {
+                if (LinkMTFOHotReload)
+                    MTFOUtil.HotReloaded -= ReloadConfig;
+                else
+                    MTFOUtil.HotReloaded += ReloadConfig;
+                LinkMTFOHotReload = !LinkMTFOHotReload;
+            }
+
+            if (UseLiveEdit != Configuration.UseLiveEdit)
+            {
+                if (UseLiveEdit)
+                    _liveEdit?.Dispose();
+                else
+                    SetupLiveEdit();
+                UseLiveEdit = !UseLiveEdit;
             }
         }
 
@@ -93,6 +115,16 @@ namespace EEC.Managers
             foreach (var config in _customizationBuffer)
             {
                 config.OnAssetLoaded();
+            }
+        }
+
+        private static void SetupLiveEdit()
+        {
+            if (Directory.Exists(BasePath))
+            {
+                _liveEdit = LiveEdit.CreateListener(BasePath, "*.*", true);
+                _liveEdit.FileChanged += LiveEdit_FileChanged;
+                _liveEdit.StartListen();
             }
         }
     }


### PR DESCRIPTION
Bleed no longer triggers dialogue or causes aim punch by default. Dialogue can be re-enabled via the user config, while aim punch is managed by the Global.json for rundown developer use.

In the interest of mechanical consistency across mods and improving default behavior, the global bleed settings now default to the commonly desired settings:
- Medipacks stop bleeding: False -> True
- Bleeding stops when downed: False -> True
- Bleeding causes aim punch: True -> False

*Note: I downloaded ALL EEC-dependent rundowns, and any that did not specify medipack stopping bleed did not use bleed, so backwards compatibility on arguably the most important setting is safe.*

Additionally, this PR adds live edit to the config file. I doubt all values are supported - I only explicitly added support for UseLiveEdit and LinkMTFOHotReload - but some of the values are read directly and will refresh correctly.