### PR TITLE
v1.8.28 - Fix projectile rotations

### DIFF
--- a/ExtraEnemyCustomization/EnemyCustomizations/Shared/Extensions/SpawnProjectileExtension.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Shared/Extensions/SpawnProjectileExtension.cs
@@ -62,10 +62,7 @@ namespace EEC.EnemyCustomizations.Shared
         {
             var yaw = Rand.Range(setting.ShotSpreadXMin, setting.ShotSpreadXMax);
             var pitch = Rand.Range(setting.ShotSpreadYMin, setting.ShotSpreadYMax);
-            var dirRot = Quaternion.LookRotation(data.BaseDirection);
-            dirRot *= Quaternion.AngleAxis(pitch, data.UpVector);
-            dirRot *= Quaternion.AngleAxis(yaw, data.RightVector);
-            var newDir = dirRot * Vector3.forward;
+            var newDir = Quaternion.LookRotation(data.BaseDirection) * Quaternion.Euler(pitch, yaw, 0) * Vector3.forward;
             ProjectileManager.WantToFireTargeting(setting.ProjectileType, data.Target, data.Position, newDir, data.OwnerID, 0f);
         }
 

--- a/ExtraEnemyCustomization/EntryPoint.cs
+++ b/ExtraEnemyCustomization/EntryPoint.cs
@@ -18,7 +18,7 @@ namespace EEC
     //TODO: - Patrolling Hibernation : Too many works to do with this one, this is one of the long term goal
     //TODO: Refactor the CustomBase to support Phase Setting
 
-    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.27")]
+    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.28")]
     [BepInProcess("GTFO.exe")]
     [BepInDependency(MTFOUtil.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("GTFO.InjectLib", BepInDependency.DependencyFlags.HardDependency)]


### PR DESCRIPTION
Very small patch. Fixes projectiles using incorrect rotational math. My brain is not wrinkled enough to know explicitly what the mathematical errors are in the old broken logic but the new math works as expected.