### PR TITLE
1.8.29

### DIFF
--- a/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/CustomProjectileManager.cs
+++ b/ExtraEnemyCustomization/CustomSettings/CustomProjectiles/CustomProjectileManager.cs
@@ -220,7 +220,7 @@ namespace EEC.CustomSettings.CustomProjectiles
                             {
                                 if (progress >= homingChange.Duration)
                                 {
-                                    projectile.Speed = originalHoming * homingChange.StopMulti;
+                                    projectile.TargetStrength = originalHoming * homingChange.StopMulti;
                                     enabled = false;
                                     return;
                                 }

--- a/ExtraEnemyCustomization/EntryPoint.cs
+++ b/ExtraEnemyCustomization/EntryPoint.cs
@@ -18,7 +18,7 @@ namespace EEC
     //TODO: - Patrolling Hibernation : Too many works to do with this one, this is one of the long term goal
     //TODO: Refactor the CustomBase to support Phase Setting
 
-    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.28")]
+    [BepInPlugin("GTFO.EECustomization", "EECustom", "1.8.29")]
     [BepInProcess("GTFO.exe")]
     [BepInDependency(MTFOUtil.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("GTFO.InjectLib", BepInDependency.DependencyFlags.HardDependency)]


### PR DESCRIPTION
Fix HomingStrengthChange StopAfterDuration setting the projectile's speed, rather than its homing strength.